### PR TITLE
feat: 学習者向け語彙API・画面を追加

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,10 @@ korean-topik-app/
 4. 実装 → `make lint-backend` → `make test`
 5. テストが通ったら `make push` → `make pr` で PR を作成
 
+### API 変更時のルール
+
+- **API を追加・変更したら Postman コレクションも必ず更新する**: `postman/korean-topik-app.postman_collection.json`
+
 ## ブランチ運用
 
 ### ブランチ構成

--- a/backend/app/Application/User/Vocabulary/GetVocabulary/GetVocabularyInput.php
+++ b/backend/app/Application/User/Vocabulary/GetVocabulary/GetVocabularyInput.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Vocabulary\GetVocabulary;
+
+final class GetVocabularyInput
+{
+    public function __construct(public readonly string $id) {}
+}

--- a/backend/app/Application/User/Vocabulary/GetVocabulary/GetVocabularyOutput.php
+++ b/backend/app/Application/User/Vocabulary/GetVocabulary/GetVocabularyOutput.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Vocabulary\GetVocabulary;
+
+final class GetVocabularyOutput
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $term,
+        public readonly string $meaningJa,
+        public readonly string $pos,
+        public readonly string $posLabelJa,
+        public readonly int $level,
+        public readonly string $levelLabelJa,
+        public readonly string $entryType,
+        public readonly string $entryTypeLabelJa,
+        public readonly ?string $exampleSentence,
+        public readonly ?string $exampleTranslationJa,
+        public readonly ?string $audioUrl,
+    ) {}
+}

--- a/backend/app/Application/User/Vocabulary/GetVocabulary/GetVocabularyUseCase.php
+++ b/backend/app/Application/User/Vocabulary/GetVocabulary/GetVocabularyUseCase.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Vocabulary\GetVocabulary;
+
+use App\Domain\Vocabulary\Exception\VocabularyNotFoundException;
+use App\Domain\Vocabulary\Repository\VocabularyRepositoryInterface;
+use App\Domain\Vocabulary\ValueObject\VocabularyId;
+use App\Domain\Vocabulary\ValueObject\VocabularyStatus;
+
+final class GetVocabularyUseCase
+{
+    public function __construct(private readonly VocabularyRepositoryInterface $vocabularies) {}
+
+    public function execute(GetVocabularyInput $input): GetVocabularyOutput
+    {
+        $vocabulary = $this->vocabularies->findByIdAndStatus(
+            new VocabularyId($input->id),
+            VocabularyStatus::PUBLISHED,
+        );
+
+        if ($vocabulary === null) {
+            throw new VocabularyNotFoundException;
+        }
+
+        return new GetVocabularyOutput(
+            id: $vocabulary->id()->value(),
+            term: $vocabulary->term()->value(),
+            meaningJa: $vocabulary->meaningJa()->value(),
+            pos: $vocabulary->pos()->value,
+            posLabelJa: $vocabulary->pos()->labelJa(),
+            level: $vocabulary->level()->value,
+            levelLabelJa: $vocabulary->level()->labelJa(),
+            entryType: $vocabulary->entryType()->value,
+            entryTypeLabelJa: $vocabulary->entryType()->labelJa(),
+            exampleSentence: $vocabulary->exampleSentence(),
+            exampleTranslationJa: $vocabulary->exampleTranslationJa(),
+            audioUrl: $vocabulary->audioUrl(),
+        );
+    }
+}

--- a/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesInput.php
+++ b/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesInput.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Vocabulary\ListVocabularies;
+
+final class ListVocabulariesInput
+{
+    public function __construct(
+        public readonly ?int $level = null,
+        public readonly ?string $entryType = null,
+        public readonly ?string $pos = null,
+    ) {}
+}

--- a/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesOutput.php
+++ b/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesOutput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Vocabulary\ListVocabularies;
+
+final class ListVocabulariesOutput
+{
+    /**
+     * @param  array<int, ListVocabulariesVocabulary>  $vocabularies
+     */
+    public function __construct(public readonly array $vocabularies) {}
+}

--- a/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesUseCase.php
+++ b/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesUseCase.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Vocabulary\ListVocabularies;
+
+use App\Domain\Vocabulary\Repository\VocabularyRepositoryInterface;
+use App\Domain\Vocabulary\ValueObject\EntryType;
+use App\Domain\Vocabulary\ValueObject\PartOfSpeech;
+use App\Domain\Vocabulary\ValueObject\TopikLevel;
+use App\Domain\Vocabulary\ValueObject\VocabularyStatus;
+
+final class ListVocabulariesUseCase
+{
+    public function __construct(private readonly VocabularyRepositoryInterface $vocabularies) {}
+
+    public function execute(ListVocabulariesInput $input): ListVocabulariesOutput
+    {
+        $level = $input->level !== null ? TopikLevel::from($input->level) : null;
+        $entryType = $input->entryType !== null ? EntryType::from($input->entryType) : null;
+        $pos = $input->pos !== null ? PartOfSpeech::from($input->pos) : null;
+
+        $items = $this->vocabularies->listByStatus(
+            VocabularyStatus::PUBLISHED,
+            level: $level,
+            entryType: $entryType,
+            pos: $pos,
+        );
+
+        return new ListVocabulariesOutput(
+            vocabularies: array_map(static fn ($v) => ListVocabulariesVocabulary::fromDomain($v), $items),
+        );
+    }
+}

--- a/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesVocabulary.php
+++ b/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesVocabulary.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Vocabulary\ListVocabularies;
+
+use App\Domain\Vocabulary\Entity\Vocabulary;
+
+final class ListVocabulariesVocabulary
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $term,
+        public readonly string $meaningJa,
+        public readonly string $pos,
+        public readonly string $posLabelJa,
+        public readonly int $level,
+        public readonly string $levelLabelJa,
+        public readonly string $entryType,
+        public readonly string $entryTypeLabelJa,
+        public readonly ?string $exampleSentence,
+        public readonly ?string $exampleTranslationJa,
+    ) {}
+
+    public static function fromDomain(Vocabulary $vocabulary): self
+    {
+        return new self(
+            id: $vocabulary->id()->value(),
+            term: $vocabulary->term()->value(),
+            meaningJa: $vocabulary->meaningJa()->value(),
+            pos: $vocabulary->pos()->value,
+            posLabelJa: $vocabulary->pos()->labelJa(),
+            level: $vocabulary->level()->value,
+            levelLabelJa: $vocabulary->level()->labelJa(),
+            entryType: $vocabulary->entryType()->value,
+            entryTypeLabelJa: $vocabulary->entryType()->labelJa(),
+            exampleSentence: $vocabulary->exampleSentence(),
+            exampleTranslationJa: $vocabulary->exampleTranslationJa(),
+        );
+    }
+}

--- a/backend/app/Domain/Vocabulary/Repository/VocabularyRepositoryInterface.php
+++ b/backend/app/Domain/Vocabulary/Repository/VocabularyRepositoryInterface.php
@@ -5,10 +5,13 @@ declare(strict_types=1);
 namespace App\Domain\Vocabulary\Repository;
 
 use App\Domain\Vocabulary\Entity\Vocabulary;
+use App\Domain\Vocabulary\ValueObject\EntryType;
 use App\Domain\Vocabulary\ValueObject\MeaningJa;
 use App\Domain\Vocabulary\ValueObject\PartOfSpeech;
 use App\Domain\Vocabulary\ValueObject\Term;
+use App\Domain\Vocabulary\ValueObject\TopikLevel;
 use App\Domain\Vocabulary\ValueObject\VocabularyId;
+use App\Domain\Vocabulary\ValueObject\VocabularyStatus;
 
 interface VocabularyRepositoryInterface
 {
@@ -18,6 +21,18 @@ interface VocabularyRepositoryInterface
     public function list(): array;
 
     public function findById(VocabularyId $id): ?Vocabulary;
+
+    /**
+     * @return array<int, Vocabulary>
+     */
+    public function listByStatus(
+        VocabularyStatus $status,
+        ?TopikLevel $level = null,
+        ?EntryType $entryType = null,
+        ?PartOfSpeech $pos = null,
+    ): array;
+
+    public function findByIdAndStatus(VocabularyId $id, VocabularyStatus $status): ?Vocabulary;
 
     public function save(Vocabulary $vocabulary): void;
 

--- a/backend/app/Http/Controllers/Api/V1/Vocabulary/VocabularyController.php
+++ b/backend/app/Http/Controllers/Api/V1/Vocabulary/VocabularyController.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Vocabulary;
+
+use App\Application\User\Vocabulary\GetVocabulary\GetVocabularyInput;
+use App\Application\User\Vocabulary\GetVocabulary\GetVocabularyUseCase;
+use App\Application\User\Vocabulary\ListVocabularies\ListVocabulariesInput;
+use App\Application\User\Vocabulary\ListVocabularies\ListVocabulariesUseCase;
+use App\Domain\Vocabulary\Exception\VocabularyNotFoundException;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class VocabularyController
+{
+    public function __construct(
+        private readonly ListVocabulariesUseCase $listVocabularies,
+        private readonly GetVocabularyUseCase $getVocabulary,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $output = $this->listVocabularies->execute(new ListVocabulariesInput(
+            level: $request->query('level') !== null ? (int) $request->query('level') : null,
+            entryType: $request->query('entry_type'),
+            pos: $request->query('pos'),
+        ));
+
+        return response()->json([
+            'vocabularies' => array_map(static fn ($v) => [
+                'id' => $v->id,
+                'term' => $v->term,
+                'meaning_ja' => $v->meaningJa,
+                'pos' => $v->pos,
+                'pos_label_ja' => $v->posLabelJa,
+                'level' => $v->level,
+                'level_label_ja' => $v->levelLabelJa,
+                'entry_type' => $v->entryType,
+                'entry_type_label_ja' => $v->entryTypeLabelJa,
+                'example_sentence' => $v->exampleSentence,
+                'example_translation_ja' => $v->exampleTranslationJa,
+            ], $output->vocabularies),
+        ]);
+    }
+
+    public function show(string $id): JsonResponse
+    {
+        try {
+            $v = $this->getVocabulary->execute(new GetVocabularyInput(id: $id));
+
+            return response()->json([
+                'vocabulary' => [
+                    'id' => $v->id,
+                    'term' => $v->term,
+                    'meaning_ja' => $v->meaningJa,
+                    'pos' => $v->pos,
+                    'pos_label_ja' => $v->posLabelJa,
+                    'level' => $v->level,
+                    'level_label_ja' => $v->levelLabelJa,
+                    'entry_type' => $v->entryType,
+                    'entry_type_label_ja' => $v->entryTypeLabelJa,
+                    'example_sentence' => $v->exampleSentence,
+                    'example_translation_ja' => $v->exampleTranslationJa,
+                    'audio_url' => $v->audioUrl,
+                ],
+            ]);
+        } catch (VocabularyNotFoundException $e) {
+            return response()->json(['message' => $e->getMessage()], 404);
+        }
+    }
+}

--- a/backend/app/Infrastructure/Vocabulary/Repository/EloquentVocabularyRepository.php
+++ b/backend/app/Infrastructure/Vocabulary/Repository/EloquentVocabularyRepository.php
@@ -6,10 +6,13 @@ namespace App\Infrastructure\Vocabulary\Repository;
 
 use App\Domain\Vocabulary\Entity\Vocabulary as DomainVocabulary;
 use App\Domain\Vocabulary\Repository\VocabularyRepositoryInterface;
+use App\Domain\Vocabulary\ValueObject\EntryType;
 use App\Domain\Vocabulary\ValueObject\MeaningJa;
 use App\Domain\Vocabulary\ValueObject\PartOfSpeech;
 use App\Domain\Vocabulary\ValueObject\Term;
+use App\Domain\Vocabulary\ValueObject\TopikLevel;
 use App\Domain\Vocabulary\ValueObject\VocabularyId;
+use App\Domain\Vocabulary\ValueObject\VocabularyStatus;
 use App\Models\Vocabulary as EloquentVocabulary;
 
 final class EloquentVocabularyRepository implements VocabularyRepositoryInterface
@@ -27,6 +30,41 @@ final class EloquentVocabularyRepository implements VocabularyRepositoryInterfac
     public function findById(VocabularyId $id): ?DomainVocabulary
     {
         $model = EloquentVocabulary::query()->find($id->value());
+
+        return $model ? VocabularyMapper::toDomain($model) : null;
+    }
+
+    public function listByStatus(
+        VocabularyStatus $status,
+        ?TopikLevel $level = null,
+        ?EntryType $entryType = null,
+        ?PartOfSpeech $pos = null,
+    ): array {
+        $q = EloquentVocabulary::query()->where('status', $status->value);
+
+        if ($level !== null) {
+            $q->where('level', $level->value);
+        }
+        if ($entryType !== null) {
+            $q->where('entry_type', $entryType->value);
+        }
+        if ($pos !== null) {
+            $q->where('pos', $pos->value);
+        }
+
+        return $q->orderBy('level')
+            ->orderBy('term')
+            ->get()
+            ->map(static fn (EloquentVocabulary $m): DomainVocabulary => VocabularyMapper::toDomain($m))
+            ->all();
+    }
+
+    public function findByIdAndStatus(VocabularyId $id, VocabularyStatus $status): ?DomainVocabulary
+    {
+        $model = EloquentVocabulary::query()
+            ->whereKey($id->value())
+            ->where('status', $status->value)
+            ->first();
 
         return $model ? VocabularyMapper::toDomain($model) : null;
     }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\V1\Admin\Auth\AdminAuthController;
 use App\Http\Controllers\Api\V1\Admin\Vocabulary\VocabularyController;
 use App\Http\Controllers\Api\V1\Auth\UserAuthController;
+use App\Http\Controllers\Api\V1\Vocabulary\VocabularyController as UserVocabularyController;
 use Illuminate\Support\Facades\Route;
 
 Route::prefix('v1')->group(function (): void {
@@ -14,6 +15,11 @@ Route::prefix('v1')->group(function (): void {
             Route::post('/logout', [UserAuthController::class, 'logout']);
             Route::get('/me', [UserAuthController::class, 'me']);
         });
+    });
+
+    Route::middleware('auth:sanctum')->group(function (): void {
+        Route::get('/vocabularies', [UserVocabularyController::class, 'index']);
+        Route::get('/vocabularies/{id}', [UserVocabularyController::class, 'show']);
     });
 
     Route::prefix('admin/auth')->group(function (): void {

--- a/backend/tests/Feature/Vocabulary/User/VocabularyApiTest.php
+++ b/backend/tests/Feature/Vocabulary/User/VocabularyApiTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature\Vocabulary\User;
+
+use App\Models\User;
+use App\Models\Vocabulary;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class VocabularyApiTest extends TestCase
+{
+    private function authHeader(): array
+    {
+        $user = User::query()->create([
+            'name' => 'Taro',
+            'email' => 'user-vocab@example.com',
+            'password' => Hash::make('password123'),
+        ]);
+
+        $token = $user->createToken('user')->plainTextToken;
+
+        return ['Authorization' => "Bearer {$token}", 'Accept' => 'application/json'];
+    }
+
+    public function test_index_returns_only_published_vocabularies(): void
+    {
+        Vocabulary::query()->create([
+            'term' => '먹다',
+            'meaning_ja' => '食べる',
+            'pos' => 'verb',
+            'level' => 1,
+            'entry_type' => 'word',
+            'status' => 'published',
+        ]);
+
+        Vocabulary::query()->create([
+            'term' => '숨기다',
+            'meaning_ja' => '隠す',
+            'pos' => 'verb',
+            'level' => 3,
+            'entry_type' => 'word',
+            'status' => 'draft',
+        ]);
+
+        $res = $this->getJson('/api/v1/vocabularies', $this->authHeader());
+
+        $res->assertOk();
+        $this->assertCount(1, $res->json('vocabularies'));
+        $res->assertJsonStructure([
+            'vocabularies' => [[
+                'id',
+                'term',
+                'meaning_ja',
+                'pos',
+                'pos_label_ja',
+                'level',
+                'level_label_ja',
+                'entry_type',
+                'entry_type_label_ja',
+                'example_sentence',
+                'example_translation_ja',
+            ]],
+        ]);
+    }
+
+    public function test_index_supports_filters(): void
+    {
+        Vocabulary::query()->create([
+            'term' => '먹다',
+            'meaning_ja' => '食べる',
+            'pos' => 'verb',
+            'level' => 1,
+            'entry_type' => 'word',
+            'status' => 'published',
+        ]);
+
+        Vocabulary::query()->create([
+            'term' => '눈이 높다',
+            'meaning_ja' => '目が肥えている',
+            'pos' => 'adj',
+            'level' => 5,
+            'entry_type' => 'idiom',
+            'status' => 'published',
+        ]);
+
+        $res = $this->getJson('/api/v1/vocabularies?level=5&entry_type=idiom&pos=adj', $this->authHeader());
+
+        $res->assertOk();
+        $this->assertCount(1, $res->json('vocabularies'));
+        $this->assertSame('눈이 높다', $res->json('vocabularies.0.term'));
+    }
+
+    public function test_show_returns_404_for_non_published(): void
+    {
+        $v = Vocabulary::query()->create([
+            'term' => '숨기다',
+            'meaning_ja' => '隠す',
+            'pos' => 'verb',
+            'level' => 3,
+            'entry_type' => 'word',
+            'status' => 'draft',
+        ]);
+
+        $res = $this->getJson("/api/v1/vocabularies/{$v->id}", $this->authHeader());
+        $res->assertNotFound();
+    }
+
+    public function test_unauthenticated_returns_401(): void
+    {
+        $res = $this->getJson('/api/v1/vocabularies', ['Accept' => 'application/json']);
+        $res->assertStatus(401);
+    }
+}

--- a/postman/korean-topik-app.postman_collection.json
+++ b/postman/korean-topik-app.postman_collection.json
@@ -22,6 +22,18 @@
       "value": ""
     },
     {
+      "key": "userEmail",
+      "value": "test@example.com"
+    },
+    {
+      "key": "userPassword",
+      "value": "password"
+    },
+    {
+      "key": "userToken",
+      "value": ""
+    },
+    {
       "key": "vocabularyId",
       "value": ""
     }
@@ -108,6 +120,214 @@
               "raw": "{{baseUrl}}/api/v1/admin/auth/logout",
               "host": ["{{baseUrl}}"],
               "path": ["api", "v1", "admin", "auth", "logout"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "User Auth",
+      "item": [
+        {
+          "name": "User Login (set userToken)",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "type": "text/javascript",
+                "exec": [
+                  "const json = pm.response.json();",
+                  "if (json && json.token) {",
+                  "  pm.collectionVariables.set('userToken', json.token);",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{userEmail}}\",\n  \"password\": \"{{userPassword}}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/login",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "login"
+              ]
+            }
+          }
+        },
+        {
+          "name": "User Me",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{userToken}}"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/me",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "me"
+              ]
+            }
+          }
+        },
+        {
+          "name": "User Logout",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{userToken}}"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/auth/logout",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "auth",
+                "logout"
+              ]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "User Vocabularies",
+      "item": [
+        {
+          "name": "List Vocabularies (published only)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{userToken}}"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/vocabularies",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "vocabularies"
+              ]
+            }
+          }
+        },
+        {
+          "name": "List Vocabularies (filters: level/entry_type/pos)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{userToken}}"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/vocabularies?level=5&entry_type=idiom&pos=adj",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "vocabularies"
+              ],
+              "query": [
+                {
+                  "key": "level",
+                  "value": "5"
+                },
+                {
+                  "key": "entry_type",
+                  "value": "idiom"
+                },
+                {
+                  "key": "pos",
+                  "value": "adj"
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Get Vocabulary",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{userToken}}"
+              },
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/vocabularies/{{vocabularyId}}",
+              "host": [
+                "{{baseUrl}}"
+              ],
+              "path": [
+                "api",
+                "v1",
+                "vocabularies",
+                "{{vocabularyId}}"
+              ]
             }
           }
         }


### PR DESCRIPTION
## 概要
学習者（User）が公開語彙を取得できる参照APIと、フロント側の語彙一覧/詳細画面を追加します。

## 変更内容
- `GET /api/v1/vocabularies` / `GET /api/v1/vocabularies/{id}` を追加（`auth:sanctum`）
- 公開語彙（`status=published`）のみ返却
- 一覧に `level` / `entry_type` / `pos` の簡易フィルタを追加
- Enumの日本語ラベル（例: `pos_label_ja`）をレスポンスに含める
- フロントに語彙一覧 `/vocabularies` と詳細 `/vocabularies/[id]` を追加
- 語彙詳細ページで動的ルートの `params` 取得を `useParams()` に修正（Next.js警告/undefined参照の解消）
- Postman コレクションを更新（User Auth / User Vocabularies を追加）
- API 変更時は Postman コレクション更新必須のルールを `AGENTS.md` に追記
- Featureテストを追加

## テスト
- [x] `make test` 通過
- [x] `make lint-backend` 通過
- [ ] 手動動作確認済み（確認内容: ）

## チェックリスト
- [ ] マイグレーションあり → `make migrate` を実行済み or 手順を本文に記載
- [x] `.env` やシークレットを含んでいない
- [x] 関連するテストを追加・更新した

## 関連
なし