### PR TITLE
feat: 学習者向け語彙一覧・詳細画面を追加

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -27,6 +27,12 @@ export default function Home() {
           >
             プロフィール
           </Link>
+          <Link
+            className="rounded-md border border-zinc-200 bg-white px-4 py-2 text-sm font-medium text-zinc-900 hover:bg-zinc-50"
+            href="/vocabularies"
+          >
+            語彙
+          </Link>
         </div>
       </div>
     </div>

--- a/frontend/src/app/vocabularies/[id]/page.tsx
+++ b/frontend/src/app/vocabularies/[id]/page.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { useAuth } from "@/components/auth/AuthProvider";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { ApiError } from "@/lib/api/http";
+import { getVocabulary, type UserVocabularyDetail } from "@/lib/api/vocabularies";
+
+export default function VocabularyDetailPage({ params }: { params: { id: string } }) {
+  const { state, refreshMe } = useAuth();
+  const [item, setItem] = useState<UserVocabularyDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (state.status === "guest") return;
+    if (state.status === "loading") {
+      refreshMe().catch(() => undefined);
+    }
+  }, [refreshMe, state.status]);
+
+  useEffect(() => {
+    const run = async () => {
+      if (state.status !== "authed") return;
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await getVocabulary(state.token, params.id);
+        setItem(res.vocabulary);
+      } catch (e) {
+        if (e instanceof ApiError) setError(e.message);
+        else setError("語彙の取得に失敗しました。");
+      } finally {
+        setLoading(false);
+      }
+    };
+    run().catch(() => undefined);
+  }, [params.id, state]);
+
+  if (state.status === "guest") {
+    return (
+      <div className="flex flex-1 items-center justify-center bg-zinc-50 px-4 py-10">
+        <Card className="w-full max-w-md">
+          <h1 className="text-xl font-semibold text-zinc-900">語彙</h1>
+          <p className="mt-2 text-sm text-zinc-600">
+            閲覧するには{" "}
+            <Link className="font-medium underline" href="/login">
+              ログイン
+            </Link>
+            が必要です。
+          </p>
+        </Card>
+      </div>
+    );
+  }
+
+  if (state.status === "loading") {
+    return (
+      <div className="flex flex-1 items-center justify-center bg-zinc-50 px-4 py-10">
+        <div className="text-sm text-zinc-600">読み込み中...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 justify-center bg-zinc-50 px-4 py-10">
+      <div className="w-full max-w-2xl space-y-4">
+        <div className="flex items-center justify-between">
+          <Link className="text-sm font-medium text-zinc-700 underline" href="/vocabularies">
+            一覧へ戻る
+          </Link>
+        </div>
+
+        <Card>
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <h1 className="truncate text-2xl font-semibold text-zinc-900">
+                {item?.term ?? "語彙"}
+              </h1>
+              <p className="mt-2 text-base text-zinc-700">{item?.meaning_ja ?? ""}</p>
+            </div>
+            <div className="shrink-0 text-right text-xs text-zinc-500">
+              <div>{item?.level_label_ja ?? ""}</div>
+              <div className="mt-1">
+                {item?.entry_type_label_ja ?? ""} / {item?.pos_label_ja ?? ""}
+              </div>
+            </div>
+          </div>
+
+          {error ? <div className="mt-4 text-sm text-red-600">{error}</div> : null}
+
+          <div className="mt-6 grid gap-3 text-sm">
+            {item?.example_sentence ? (
+              <div>
+                <div className="text-zinc-500">例文</div>
+                <div className="mt-1 text-zinc-900">{item.example_sentence}</div>
+              </div>
+            ) : null}
+            {item?.example_translation_ja ? (
+              <div>
+                <div className="text-zinc-500">例文（日本語）</div>
+                <div className="mt-1 text-zinc-900">{item.example_translation_ja}</div>
+              </div>
+            ) : null}
+          </div>
+
+          <div className="mt-6 flex gap-3">
+            <Button
+              variant="secondary"
+              type="button"
+              disabled={loading}
+              onClick={() => {
+                if (state.status !== "authed") return;
+                setLoading(true);
+                getVocabulary(state.token, params.id)
+                  .then((res) => setItem(res.vocabulary))
+                  .catch((e) => {
+                    if (e instanceof ApiError) setError(e.message);
+                    else setError("語彙の取得に失敗しました。");
+                  })
+                  .finally(() => setLoading(false));
+              }}
+            >
+              {loading ? "更新中..." : "更新"}
+            </Button>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/app/vocabularies/[id]/page.tsx
+++ b/frontend/src/app/vocabularies/[id]/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -9,8 +10,10 @@ import { Card } from "@/components/ui/Card";
 import { ApiError } from "@/lib/api/http";
 import { getVocabulary, type UserVocabularyDetail } from "@/lib/api/vocabularies";
 
-export default function VocabularyDetailPage({ params }: { params: { id: string } }) {
+export default function VocabularyDetailPage() {
   const { state, refreshMe } = useAuth();
+  const params = useParams<{ id?: string }>();
+  const id = typeof params?.id === "string" ? params.id : "";
   const [item, setItem] = useState<UserVocabularyDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
@@ -25,10 +28,11 @@ export default function VocabularyDetailPage({ params }: { params: { id: string 
   useEffect(() => {
     const run = async () => {
       if (state.status !== "authed") return;
+      if (!id) return;
       setLoading(true);
       setError(null);
       try {
-        const res = await getVocabulary(state.token, params.id);
+        const res = await getVocabulary(state.token, id);
         setItem(res.vocabulary);
       } catch (e) {
         if (e instanceof ApiError) setError(e.message);
@@ -38,7 +42,7 @@ export default function VocabularyDetailPage({ params }: { params: { id: string 
       }
     };
     run().catch(() => undefined);
-  }, [params.id, state]);
+  }, [id, state]);
 
   if (state.status === "guest") {
     return (
@@ -114,8 +118,9 @@ export default function VocabularyDetailPage({ params }: { params: { id: string 
               disabled={loading}
               onClick={() => {
                 if (state.status !== "authed") return;
+                if (!id) return;
                 setLoading(true);
-                getVocabulary(state.token, params.id)
+                getVocabulary(state.token, id)
                   .then((res) => setItem(res.vocabulary))
                   .catch((e) => {
                     if (e instanceof ApiError) setError(e.message);

--- a/frontend/src/app/vocabularies/page.tsx
+++ b/frontend/src/app/vocabularies/page.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+
+import { useAuth } from "@/components/auth/AuthProvider";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { ApiError } from "@/lib/api/http";
+import { listVocabularies, type UserVocabulary } from "@/lib/api/vocabularies";
+
+type Filters = {
+  level: string;
+  entry_type: string;
+  pos: string;
+};
+
+const POS_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "", label: "すべて" },
+  { value: "noun", label: "名詞" },
+  { value: "verb", label: "動詞" },
+  { value: "adj", label: "形容詞" },
+  { value: "adv", label: "副詞" },
+  { value: "particle", label: "助詞" },
+  { value: "determiner", label: "冠形詞" },
+  { value: "pronoun", label: "代名詞" },
+  { value: "interjection", label: "感動詞" },
+  { value: "other", label: "その他" },
+];
+
+const ENTRY_TYPE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: "", label: "すべて" },
+  { value: "word", label: "単語" },
+  { value: "phrase", label: "熟語" },
+  { value: "idiom", label: "慣用句" },
+];
+
+export default function VocabulariesPage() {
+  const { state, refreshMe } = useAuth();
+  const [filters, setFilters] = useState<Filters>({ level: "", entry_type: "", pos: "" });
+  const [items, setItems] = useState<UserVocabulary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const query = useMemo(() => {
+    const level = filters.level ? Number(filters.level) : undefined;
+    return {
+      level: Number.isFinite(level) ? level : undefined,
+      entry_type: filters.entry_type || undefined,
+      pos: filters.pos || undefined,
+    };
+  }, [filters]);
+
+  useEffect(() => {
+    if (state.status === "guest") return;
+    if (state.status === "loading") {
+      refreshMe().catch(() => undefined);
+    }
+  }, [refreshMe, state.status]);
+
+  useEffect(() => {
+    const run = async () => {
+      if (state.status !== "authed") return;
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await listVocabularies(state.token, query);
+        setItems(res.vocabularies);
+      } catch (e) {
+        if (e instanceof ApiError) setError(e.message);
+        else setError("語彙の取得に失敗しました。");
+      } finally {
+        setLoading(false);
+      }
+    };
+    run().catch(() => undefined);
+  }, [query, state]);
+
+  if (state.status === "guest") {
+    return (
+      <div className="flex flex-1 items-center justify-center bg-zinc-50 px-4 py-10">
+        <Card className="w-full max-w-md">
+          <h1 className="text-xl font-semibold text-zinc-900">語彙</h1>
+          <p className="mt-2 text-sm text-zinc-600">
+            閲覧するには{" "}
+            <Link className="font-medium underline" href="/login">
+              ログイン
+            </Link>
+            が必要です。
+          </p>
+        </Card>
+      </div>
+    );
+  }
+
+  if (state.status === "loading") {
+    return (
+      <div className="flex flex-1 items-center justify-center bg-zinc-50 px-4 py-10">
+        <div className="text-sm text-zinc-600">読み込み中...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex flex-1 justify-center bg-zinc-50 px-4 py-10">
+      <div className="w-full max-w-4xl space-y-4">
+        <Card>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-zinc-900">語彙</h1>
+              <p className="mt-1 text-sm text-zinc-600">公開中の語彙のみ表示します。</p>
+            </div>
+            <div className="flex gap-2">
+              <Button
+                variant="secondary"
+                type="button"
+                onClick={() => setFilters({ level: "", entry_type: "", pos: "" })}
+              >
+                フィルタ解除
+              </Button>
+            </div>
+          </div>
+
+          <div className="mt-6 grid grid-cols-1 gap-3 sm:grid-cols-3">
+            <label className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-zinc-800">TOPIK</span>
+              <select
+                className="h-10 rounded-md border border-zinc-200 bg-white px-3 text-sm outline-none focus:ring-2 focus:ring-zinc-900/20"
+                value={filters.level}
+                onChange={(e) => setFilters((p) => ({ ...p, level: e.target.value }))}
+              >
+                <option value="">すべて</option>
+                {[1, 2, 3, 4, 5, 6].map((n) => (
+                  <option key={n} value={String(n)}>
+                    {n}級
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-zinc-800">種別</span>
+              <select
+                className="h-10 rounded-md border border-zinc-200 bg-white px-3 text-sm outline-none focus:ring-2 focus:ring-zinc-900/20"
+                value={filters.entry_type}
+                onChange={(e) => setFilters((p) => ({ ...p, entry_type: e.target.value }))}
+              >
+                {ENTRY_TYPE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label className="flex flex-col gap-1">
+              <span className="text-sm font-medium text-zinc-800">品詞</span>
+              <select
+                className="h-10 rounded-md border border-zinc-200 bg-white px-3 text-sm outline-none focus:ring-2 focus:ring-zinc-900/20"
+                value={filters.pos}
+                onChange={(e) => setFilters((p) => ({ ...p, pos: e.target.value }))}
+              >
+                {POS_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+          </div>
+        </Card>
+
+        <Card>
+          <div className="flex items-center justify-between">
+            <div className="text-sm text-zinc-600">
+              {loading ? "読み込み中..." : `件数: ${items?.length ?? 0}`}
+            </div>
+            {error ? <div className="text-sm text-red-600">{error}</div> : null}
+          </div>
+
+          <div className="mt-4 divide-y divide-zinc-200">
+            {(items ?? []).map((v) => (
+              <Link
+                key={v.id}
+                href={`/vocabularies/${v.id}`}
+                className="block py-3 hover:bg-zinc-50 -mx-6 px-6"
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <div className="truncate text-base font-medium text-zinc-900">{v.term}</div>
+                    <div className="mt-1 truncate text-sm text-zinc-600">{v.meaning_ja}</div>
+                  </div>
+                  <div className="shrink-0 text-right text-xs text-zinc-500">
+                    <div>{v.level_label_ja}</div>
+                    <div className="mt-1">
+                      {v.entry_type_label_ja} / {v.pos_label_ja}
+                    </div>
+                  </div>
+                </div>
+              </Link>
+            ))}
+
+            {!loading && items && items.length === 0 ? (
+              <div className="py-8 text-center text-sm text-zinc-600">該当する語彙がありません。</div>
+            ) : null}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/lib/api/vocabularies.ts
+++ b/frontend/src/lib/api/vocabularies.ts
@@ -1,0 +1,40 @@
+import { apiFetch } from "./http";
+
+export type UserVocabulary = {
+  id: string;
+  term: string;
+  meaning_ja: string;
+  pos: string;
+  pos_label_ja: string;
+  level: number;
+  level_label_ja: string;
+  entry_type: string;
+  entry_type_label_ja: string;
+  example_sentence?: string | null;
+  example_translation_ja?: string | null;
+};
+
+export type UserVocabularyDetail = UserVocabulary & {
+  audio_url?: string | null;
+};
+
+export async function listVocabularies(
+  token: string,
+  input: { level?: number; entry_type?: string; pos?: string } = {}
+): Promise<{ vocabularies: UserVocabulary[] }> {
+  const qs = new URLSearchParams();
+  if (typeof input.level === "number") qs.set("level", String(input.level));
+  if (input.entry_type) qs.set("entry_type", input.entry_type);
+  if (input.pos) qs.set("pos", input.pos);
+  const suffix = qs.toString() ? `?${qs.toString()}` : "";
+
+  return apiFetch(`/api/v1/vocabularies${suffix}`, { method: "GET", token });
+}
+
+export async function getVocabulary(
+  token: string,
+  id: string
+): Promise<{ vocabulary: UserVocabularyDetail }> {
+  return apiFetch(`/api/v1/vocabularies/${encodeURIComponent(id)}`, { method: "GET", token });
+}
+


### PR DESCRIPTION
## 概要
学習者（User）が語彙を閲覧できる画面（一覧・詳細）を追加します。
既存の学習者向け語彙参照API（`/api/v1/vocabularies`）を利用し、ログイン済みユーザーがフィルタ付きで語彙を探せるようにします。

## 変更内容
- 語彙一覧ページ `/vocabularies` を追加（TOPIK/種別/品詞のフィルタ、件数表示）
- 語彙詳細ページ `/vocabularies/[id]` を追加（例文/訳の表示、更新ボタン）
- 学習者向け語彙APIクライアント `frontend/src/lib/api/vocabularies.ts` を追加
- Next.js の動的ルート仕様に合わせ、語彙詳細で `useParams()` を使って `id` を取得するよう修正（`params` Promise 警告と `undefined` 参照を解消）
- ホーム `/` から語彙画面への導線を追加

## テスト
- [x] `make test` 通過
- [ ] `make lint-backend` 通過（バックエンド差分なし）
- [ ] 手動動作確認済み（確認内容: ログイン→語彙一覧表示→フィルタ→詳細遷移→更新）

## チェックリスト
- [ ] マイグレーションあり → `make migrate` を実行済み or 手順を本文に記載（なし）
- [x] `.env` やシークレットを含んでいない
- [x] 関連するテストを追加・更新した（既存テストに影響なし）

## 関連
なし