### PR TITLE
feat: 学習者画面のナビゲーションを整備

### DIFF
--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -17,10 +17,9 @@ Route::prefix('v1')->group(function (): void {
         });
     });
 
-    Route::middleware('auth:sanctum')->group(function (): void {
-        Route::get('/vocabularies', [UserVocabularyController::class, 'index']);
-        Route::get('/vocabularies/{id}', [UserVocabularyController::class, 'show']);
-    });
+    // Public: allow guest to browse published vocabularies.
+    Route::get('/vocabularies', [UserVocabularyController::class, 'index']);
+    Route::get('/vocabularies/{id}', [UserVocabularyController::class, 'show']);
 
     Route::prefix('admin/auth')->group(function (): void {
         Route::post('/login', [AdminAuthController::class, 'login']);

--- a/backend/tests/Feature/Vocabulary/User/VocabularyApiTest.php
+++ b/backend/tests/Feature/Vocabulary/User/VocabularyApiTest.php
@@ -42,7 +42,7 @@ class VocabularyApiTest extends TestCase
             'status' => 'draft',
         ]);
 
-        $res = $this->getJson('/api/v1/vocabularies', $this->authHeader());
+        $res = $this->getJson('/api/v1/vocabularies', ['Accept' => 'application/json']);
 
         $res->assertOk();
         $this->assertCount(1, $res->json('vocabularies'));
@@ -83,7 +83,7 @@ class VocabularyApiTest extends TestCase
             'status' => 'published',
         ]);
 
-        $res = $this->getJson('/api/v1/vocabularies?level=5&entry_type=idiom&pos=adj', $this->authHeader());
+        $res = $this->getJson('/api/v1/vocabularies?level=5&entry_type=idiom&pos=adj', ['Accept' => 'application/json']);
 
         $res->assertOk();
         $this->assertCount(1, $res->json('vocabularies'));
@@ -101,13 +101,22 @@ class VocabularyApiTest extends TestCase
             'status' => 'draft',
         ]);
 
-        $res = $this->getJson("/api/v1/vocabularies/{$v->id}", $this->authHeader());
+        $res = $this->getJson("/api/v1/vocabularies/{$v->id}", ['Accept' => 'application/json']);
         $res->assertNotFound();
     }
 
-    public function test_unauthenticated_returns_401(): void
+    public function test_index_allows_guest_access(): void
     {
+        Vocabulary::query()->create([
+            'term' => '먹다',
+            'meaning_ja' => '食べる',
+            'pos' => 'verb',
+            'level' => 1,
+            'entry_type' => 'word',
+            'status' => 'published',
+        ]);
+
         $res = $this->getJson('/api/v1/vocabularies', ['Accept' => 'application/json']);
-        $res->assertStatus(401);
+        $res->assertOk();
     }
 }

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,17 +1,18 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Geist_Mono, Noto_Sans_KR } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/components/auth/AuthProvider";
 import { AppHeader } from "@/components/nav/AppHeader";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
 const geistMono = Geist_Mono({
   variable: "--font-geist-mono",
   subsets: ["latin"],
+});
+
+const notoSansKr = Noto_Sans_KR({
+  variable: "--font-noto-sans-kr",
+  subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
 });
 
 export const metadata: Metadata = {
@@ -27,7 +28,7 @@ export default function RootLayout({
   return (
     <html
       lang="en"
-      className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${notoSansKr.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
         <AuthProvider>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/components/auth/AuthProvider";
+import { AppHeader } from "@/components/nav/AppHeader";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -29,7 +30,10 @@ export default function RootLayout({
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
-        <AuthProvider>{children}</AuthProvider>
+        <AuthProvider>
+          <AppHeader />
+          {children}
+        </AuthProvider>
       </body>
     </html>
   );

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -5,12 +5,16 @@ export default function Home() {
     <div className="flex flex-1 items-center justify-center bg-zinc-50 px-4 py-10">
       <div className="w-full max-w-xl rounded-2xl border border-zinc-200 bg-white p-8 shadow-sm">
         <h1 className="text-2xl font-semibold text-zinc-900">Korean TOPIK App</h1>
-        <p className="mt-2 text-sm text-zinc-600">
-          認証フロー（User）を確認できます。
-        </p>
+        <p className="mt-2 text-sm text-zinc-600">学習者向けの語彙一覧・詳細を確認できます。</p>
         <div className="mt-6 flex flex-wrap gap-3">
           <Link
             className="rounded-md bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800"
+            href="/vocabularies"
+          >
+            語彙を見る
+          </Link>
+          <Link
+            className="rounded-md border border-zinc-200 bg-white px-4 py-2 text-sm font-medium text-zinc-900 hover:bg-zinc-50"
             href="/login"
           >
             ログイン
@@ -26,12 +30,6 @@ export default function Home() {
             href="/me"
           >
             プロフィール
-          </Link>
-          <Link
-            className="rounded-md border border-zinc-200 bg-white px-4 py-2 text-sm font-medium text-zinc-900 hover:bg-zinc-50"
-            href="/vocabularies"
-          >
-            語彙
           </Link>
         </div>
       </div>

--- a/frontend/src/app/vocabularies/[id]/page.tsx
+++ b/frontend/src/app/vocabularies/[id]/page.tsx
@@ -27,7 +27,6 @@ export default function VocabularyDetailPage() {
   const [loading, setLoading] = useState(false);
 
   useEffect(() => {
-    if (state.status === "guest") return;
     if (state.status === "loading") {
       refreshMe().catch(() => undefined);
     }
@@ -35,12 +34,12 @@ export default function VocabularyDetailPage() {
 
   useEffect(() => {
     const run = async () => {
-      if (state.status !== "authed") return;
       if (!id) return;
       setLoading(true);
       setError(null);
       try {
-        const res = await getVocabulary(state.token, id);
+        const token = state.status === "authed" ? state.token : null;
+        const res = await getVocabulary(token, id);
         setItem(res.vocabulary);
       } catch (e) {
         if (e instanceof ApiError) setError(e.message);
@@ -51,23 +50,6 @@ export default function VocabularyDetailPage() {
     };
     run().catch(() => undefined);
   }, [id, state]);
-
-  if (state.status === "guest") {
-    return (
-      <div className="flex flex-1 items-center justify-center bg-zinc-50 px-4 py-10">
-        <Card className="w-full max-w-md">
-          <h1 className="text-xl font-semibold text-zinc-900">語彙</h1>
-          <p className="mt-2 text-sm text-zinc-600">
-            閲覧するには{" "}
-            <Link className="font-medium underline" href="/login">
-              ログイン
-            </Link>
-            が必要です。
-          </p>
-        </Card>
-      </div>
-    );
-  }
 
   if (state.status === "loading") {
     return (
@@ -152,10 +134,10 @@ export default function VocabularyDetailPage() {
               type="button"
               disabled={loading}
               onClick={() => {
-                if (state.status !== "authed") return;
                 if (!id) return;
                 setLoading(true);
-                getVocabulary(state.token, id)
+                const token = state.status === "authed" ? state.token : null;
+                getVocabulary(token, id)
                   .then((res) => setItem(res.vocabulary))
                   .catch((e) => {
                     if (e instanceof ApiError) setError(e.message);

--- a/frontend/src/app/vocabularies/[id]/page.tsx
+++ b/frontend/src/app/vocabularies/[id]/page.tsx
@@ -10,6 +10,14 @@ import { Card } from "@/components/ui/Card";
 import { ApiError } from "@/lib/api/http";
 import { getVocabulary, type UserVocabularyDetail } from "@/lib/api/vocabularies";
 
+function Tag({ children }: { children: React.ReactNode }) {
+  return (
+    <span className="inline-flex items-center rounded-full bg-zinc-100 px-3 py-1 text-xs font-medium text-zinc-700">
+      {children}
+    </span>
+  );
+}
+
 export default function VocabularyDetailPage() {
   const { state, refreshMe } = useAuth();
   const params = useParams<{ id?: string }>();
@@ -73,47 +81,74 @@ export default function VocabularyDetailPage() {
     <div className="flex flex-1 justify-center bg-zinc-50 px-4 py-10">
       <div className="w-full max-w-2xl space-y-4">
         <div className="flex items-center justify-between">
-          <Link className="text-sm font-medium text-zinc-700 underline" href="/vocabularies">
-            一覧へ戻る
+          <Link
+            className="inline-flex items-center gap-2 rounded-full bg-zinc-100 px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-200"
+            href="/vocabularies"
+          >
+            <span aria-hidden="true">←</span>
+            一覧に戻る
           </Link>
         </div>
 
         <Card>
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0">
-              <h1 className="truncate text-2xl font-semibold text-zinc-900">
-                {item?.term ?? "語彙"}
-              </h1>
-              <p className="mt-2 text-base text-zinc-700">{item?.meaning_ja ?? ""}</p>
-            </div>
-            <div className="shrink-0 text-right text-xs text-zinc-500">
-              <div>{item?.level_label_ja ?? ""}</div>
-              <div className="mt-1">
-                {item?.entry_type_label_ja ?? ""} / {item?.pos_label_ja ?? ""}
+          <div className="flex flex-col gap-4">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <h1 className="truncate text-3xl font-bold tracking-tight text-zinc-900 sm:text-4xl">
+                  {item?.term ?? "語彙"}
+                </h1>
+                <p className="mt-2 text-lg font-semibold text-zinc-900">{item?.meaning_ja ?? ""}</p>
               </div>
+              <div className="shrink-0 text-right text-xs text-zinc-500">
+                <div className="font-medium">{item?.level_label_ja ?? ""}</div>
+                <div className="mt-1">{item?.pos_label_ja ?? ""}</div>
+              </div>
+            </div>
+
+            <div className="flex flex-wrap gap-2">
+              {item?.level_label_ja ? <Tag>{item.level_label_ja}</Tag> : null}
+              {item?.entry_type_label_ja ? <Tag>{item.entry_type_label_ja}</Tag> : null}
+              {item?.pos_label_ja ? <Tag>{item.pos_label_ja}</Tag> : null}
             </div>
           </div>
 
           {error ? <div className="mt-4 text-sm text-red-600">{error}</div> : null}
 
-          <div className="mt-6 grid gap-3 text-sm">
+          <div className="my-6 h-px bg-zinc-200" />
+
+          <div className="grid gap-4 text-sm">
+            <div className="text-sm font-semibold text-zinc-900">例文</div>
+
             {item?.example_sentence ? (
-              <div>
-                <div className="text-zinc-500">例文</div>
-                <div className="mt-1 text-zinc-900">{item.example_sentence}</div>
+              <div className="flex gap-2">
+                <div
+                  className="shrink-0 self-start text-base leading-none"
+                  aria-hidden="true"
+                >
+                  🇰🇷
+                </div>
+                <div className="text-zinc-900">{item.example_sentence}</div>
               </div>
-            ) : null}
+            ) : (
+              <div className="text-zinc-500">例文は未登録です。</div>
+            )}
+
             {item?.example_translation_ja ? (
-              <div>
-                <div className="text-zinc-500">例文（日本語）</div>
-                <div className="mt-1 text-zinc-900">{item.example_translation_ja}</div>
+              <div className="flex gap-2">
+                <div
+                  className="shrink-0 self-start text-base leading-none"
+                  aria-hidden="true"
+                >
+                  🇯🇵
+                </div>
+                <div className="text-zinc-700">{item.example_translation_ja}</div>
               </div>
             ) : null}
           </div>
 
           <div className="mt-6 flex gap-3">
             <Button
-              variant="secondary"
+              className="w-full sm:w-auto"
               type="button"
               disabled={loading}
               onClick={() => {

--- a/frontend/src/app/vocabularies/page.tsx
+++ b/frontend/src/app/vocabularies/page.tsx
@@ -52,7 +52,6 @@ export default function VocabulariesPage() {
   }, [filters]);
 
   useEffect(() => {
-    if (state.status === "guest") return;
     if (state.status === "loading") {
       refreshMe().catch(() => undefined);
     }
@@ -60,11 +59,11 @@ export default function VocabulariesPage() {
 
   useEffect(() => {
     const run = async () => {
-      if (state.status !== "authed") return;
       setLoading(true);
       setError(null);
       try {
-        const res = await listVocabularies(state.token, query);
+        const token = state.status === "authed" ? state.token : null;
+        const res = await listVocabularies(token, query);
         setItems(res.vocabularies);
       } catch (e) {
         if (e instanceof ApiError) setError(e.message);
@@ -75,23 +74,6 @@ export default function VocabulariesPage() {
     };
     run().catch(() => undefined);
   }, [query, state]);
-
-  if (state.status === "guest") {
-    return (
-      <div className="flex flex-1 items-center justify-center bg-zinc-50 px-4 py-10">
-        <Card className="w-full max-w-md">
-          <h1 className="text-xl font-semibold text-zinc-900">語彙</h1>
-          <p className="mt-2 text-sm text-zinc-600">
-            閲覧するには{" "}
-            <Link className="font-medium underline" href="/login">
-              ログイン
-            </Link>
-            が必要です。
-          </p>
-        </Card>
-      </div>
-    );
-  }
 
   if (state.status === "loading") {
     return (

--- a/frontend/src/components/nav/AppHeader.tsx
+++ b/frontend/src/components/nav/AppHeader.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { useMemo } from "react";
+
+import { useAuth } from "@/components/auth/AuthProvider";
+import { Button } from "@/components/ui/Button";
+
+function NavLink({
+  href,
+  label,
+}: {
+  href: string;
+  label: string;
+}) {
+  const pathname = usePathname();
+  const isActive = useMemo(() => {
+    if (!pathname) return false;
+    if (href === "/") return pathname === "/";
+    return pathname === href || pathname.startsWith(`${href}/`);
+  }, [href, pathname]);
+
+  const base =
+    "rounded-md px-3 py-2 text-sm font-medium transition-colors";
+  const cls = isActive
+    ? `${base} bg-zinc-900 text-white`
+    : `${base} text-zinc-700 hover:bg-zinc-100`;
+
+  return (
+    <Link className={cls} href={href}>
+      {label}
+    </Link>
+  );
+}
+
+export function AppHeader() {
+  const { state, logout } = useAuth();
+
+  return (
+    <header className="border-b border-zinc-200 bg-white">
+      <div className="mx-auto flex w-full max-w-5xl items-center justify-between gap-4 px-4 py-3">
+        <div className="flex items-center gap-3">
+          <Link href="/" className="text-sm font-semibold text-zinc-900">
+            Korean TOPIK App
+          </Link>
+          <nav className="hidden items-center gap-1 sm:flex">
+            <NavLink href="/vocabularies" label="語彙" />
+            <NavLink href="/me" label="プロフィール" />
+          </nav>
+        </div>
+
+        <div className="flex items-center gap-2">
+          {state.status === "authed" ? (
+            <>
+              <div className="hidden text-sm text-zinc-600 sm:block">
+                {state.user.name}
+              </div>
+              <Button variant="secondary" type="button" onClick={() => logout()}>
+                ログアウト
+              </Button>
+            </>
+          ) : (
+            <>
+              <Link
+                className="rounded-md px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100"
+                href="/login"
+              >
+                ログイン
+              </Link>
+              <Link
+                className="rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800"
+                href="/register"
+              >
+                新規登録
+              </Link>
+            </>
+          )}
+        </div>
+      </div>
+
+      <div className="mx-auto w-full max-w-5xl px-4 pb-3 sm:hidden">
+        <nav className="flex items-center gap-1">
+          <NavLink href="/vocabularies" label="語彙" />
+          <NavLink href="/me" label="プロフィール" />
+        </nav>
+      </div>
+    </header>
+  );
+}
+

--- a/frontend/src/lib/api/vocabularies.ts
+++ b/frontend/src/lib/api/vocabularies.ts
@@ -19,7 +19,7 @@ export type UserVocabularyDetail = UserVocabulary & {
 };
 
 export async function listVocabularies(
-  token: string,
+  token: string | null,
   input: { level?: number; entry_type?: string; pos?: string } = {}
 ): Promise<{ vocabularies: UserVocabulary[] }> {
   const qs = new URLSearchParams();
@@ -32,7 +32,7 @@ export async function listVocabularies(
 }
 
 export async function getVocabulary(
-  token: string,
+  token: string | null,
   id: string
 ): Promise<{ vocabulary: UserVocabularyDetail }> {
   return apiFetch(`/api/v1/vocabularies/${encodeURIComponent(id)}`, { method: "GET", token });

--- a/postman/korean-topik-app.postman_collection.json
+++ b/postman/korean-topik-app.postman_collection.json
@@ -241,10 +241,6 @@
             "method": "GET",
             "header": [
               {
-                "key": "Authorization",
-                "value": "Bearer {{userToken}}"
-              },
-              {
                 "key": "Accept",
                 "value": "application/json"
               }
@@ -267,10 +263,6 @@
           "request": {
             "method": "GET",
             "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{userToken}}"
-              },
               {
                 "key": "Accept",
                 "value": "application/json"
@@ -308,10 +300,6 @@
           "request": {
             "method": "GET",
             "header": [
-              {
-                "key": "Authorization",
-                "value": "Bearer {{userToken}}"
-              },
               {
                 "key": "Accept",
                 "value": "application/json"


### PR DESCRIPTION
## 概要
学習者向け画面で移動しやすいように、共通ヘッダー（ナビゲーション）を追加します。
ログイン状態に応じて表示を切り替え、語彙/プロフィールへの導線を整理します。併せて Google Fonts（Noto Sans KR）を適用し、韓国語表示の可読性を改善します。

## 変更内容
- 全ページ共通のヘッダーを追加
- 語彙一覧 `/vocabularies` / プロフィール `/me` への導線を常時表示
- ログイン状態に応じて以下を表示
  - 未ログイン: ログイン / 新規登録
  - ログイン済み: ユーザー名 / ログアウト
- ホーム `/` のリンクも整理
- Google Fonts（Noto Sans KR）を全体フォントに適用

## テスト
- [x] `make test` 通過
- [ ] `make lint-backend` 通過（バックエンド差分なし）
- [ ] 手動動作確認済み（確認内容: ）

## チェックリスト
- [ ] マイグレーションあり → `make migrate` を実行済み or 手順を本文に記載（なし）
- [x] `.env` やシークレットを含んでいない
- [x] 関連するテストを追加・更新した（既存テストに影響なし）

## 関連
なし