### PR TITLE
feat: 管理者ログインと語彙一覧画面

### DIFF
--- a/backend/app/Http/Controllers/Api/V1/Admin/Vocabulary/VocabularyController.php
+++ b/backend/app/Http/Controllers/Api/V1/Admin/Vocabulary/VocabularyController.php
@@ -13,6 +13,10 @@ use App\Application\Admin\Vocabulary\UpdateVocabulary\UpdateVocabularyInput;
 use App\Application\Admin\Vocabulary\UpdateVocabulary\UpdateVocabularyUseCase;
 use App\Domain\Vocabulary\Exception\VocabularyAlreadyExistsException;
 use App\Domain\Vocabulary\Exception\VocabularyNotFoundException;
+use App\Domain\Vocabulary\ValueObject\EntryType;
+use App\Domain\Vocabulary\ValueObject\PartOfSpeech;
+use App\Domain\Vocabulary\ValueObject\TopikLevel;
+use App\Domain\Vocabulary\ValueObject\VocabularyStatus;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Api\V1\Admin\Vocabulary\StoreVocabularyRequest;
 use App\Http\Requests\Api\V1\Admin\Vocabulary\UpdateVocabularyRequest;
@@ -38,12 +42,16 @@ class VocabularyController extends Controller
                 'term' => $v->term,
                 'meaning_ja' => $v->meaningJa,
                 'pos' => $v->pos,
+                'pos_label_ja' => PartOfSpeech::from($v->pos)->labelJa(),
                 'level' => $v->level,
+                'level_label_ja' => TopikLevel::from($v->level)->labelJa(),
                 'entry_type' => $v->entryType,
+                'entry_type_label_ja' => EntryType::from($v->entryType)->labelJa(),
                 'example_sentence' => $v->exampleSentence,
                 'example_translation_ja' => $v->exampleTranslationJa,
                 'audio_url' => $v->audioUrl,
                 'status' => $v->status,
+                'status_label_ja' => VocabularyStatus::from($v->status)->labelJa(),
                 'created_at' => $v->createdAt,
             ], $output->vocabularies),
         ]);
@@ -60,12 +68,16 @@ class VocabularyController extends Controller
                     'term' => $v->term,
                     'meaning_ja' => $v->meaningJa,
                     'pos' => $v->pos,
+                    'pos_label_ja' => PartOfSpeech::from($v->pos)->labelJa(),
                     'level' => $v->level,
+                    'level_label_ja' => TopikLevel::from($v->level)->labelJa(),
                     'entry_type' => $v->entryType,
+                    'entry_type_label_ja' => EntryType::from($v->entryType)->labelJa(),
                     'example_sentence' => $v->exampleSentence,
                     'example_translation_ja' => $v->exampleTranslationJa,
                     'audio_url' => $v->audioUrl,
                     'status' => $v->status,
+                    'status_label_ja' => VocabularyStatus::from($v->status)->labelJa(),
                     'created_at' => $v->createdAt,
                 ],
             ]);
@@ -95,12 +107,16 @@ class VocabularyController extends Controller
                     'term' => $v->term,
                     'meaning_ja' => $v->meaningJa,
                     'pos' => $v->pos,
+                    'pos_label_ja' => PartOfSpeech::from($v->pos)->labelJa(),
                     'level' => $v->level,
+                    'level_label_ja' => TopikLevel::from($v->level)->labelJa(),
                     'entry_type' => $v->entryType,
+                    'entry_type_label_ja' => EntryType::from($v->entryType)->labelJa(),
                     'example_sentence' => $v->exampleSentence,
                     'example_translation_ja' => $v->exampleTranslationJa,
                     'audio_url' => $v->audioUrl,
                     'status' => $v->status,
+                    'status_label_ja' => VocabularyStatus::from($v->status)->labelJa(),
                     'created_at' => $v->createdAt,
                 ],
             ], 201);
@@ -131,12 +147,16 @@ class VocabularyController extends Controller
                     'term' => $v->term,
                     'meaning_ja' => $v->meaningJa,
                     'pos' => $v->pos,
+                    'pos_label_ja' => PartOfSpeech::from($v->pos)->labelJa(),
                     'level' => $v->level,
+                    'level_label_ja' => TopikLevel::from($v->level)->labelJa(),
                     'entry_type' => $v->entryType,
+                    'entry_type_label_ja' => EntryType::from($v->entryType)->labelJa(),
                     'example_sentence' => $v->exampleSentence,
                     'example_translation_ja' => $v->exampleTranslationJa,
                     'audio_url' => $v->audioUrl,
                     'status' => $v->status,
+                    'status_label_ja' => VocabularyStatus::from($v->status)->labelJa(),
                     'created_at' => $v->createdAt,
                 ],
             ]);

--- a/frontend/src/app/admin/login/page.tsx
+++ b/frontend/src/app/admin/login/page.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { ApiError } from "@/lib/api/http";
+import { loginAdmin } from "@/lib/api/admin/auth";
+
+const ADMIN_TOKEN_KEY = "topik.admin.token";
+
+export default function AdminLoginPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const nextPath = useMemo(() => searchParams.get("next") || "/admin/vocabularies", [searchParams]);
+
+  const [email, setEmail] = useState("admin@example.com");
+  const [password, setPassword] = useState("password");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const token = window.localStorage.getItem(ADMIN_TOKEN_KEY);
+    if (token) router.replace(nextPath);
+  }, [nextPath, router]);
+
+  return (
+    <div className="flex flex-1 items-center justify-center bg-zinc-50 px-4 py-10">
+      <Card className="w-full max-w-md">
+        <div className="flex items-center justify-between">
+          <h1 className="text-xl font-semibold text-zinc-900">管理者ログイン</h1>
+          <Link className="text-sm font-medium text-zinc-700 underline" href="/">
+            学習者画面へ
+          </Link>
+        </div>
+
+        <form
+          className="mt-6 space-y-4"
+          onSubmit={(e) => {
+            e.preventDefault();
+            setLoading(true);
+            setError(null);
+            loginAdmin({ email, password })
+              .then((res) => {
+                window.localStorage.setItem(ADMIN_TOKEN_KEY, res.token);
+                router.push(nextPath);
+              })
+              .catch((e2) => {
+                if (e2 instanceof ApiError) setError(e2.message);
+                else setError("ログインに失敗しました。");
+              })
+              .finally(() => setLoading(false));
+          }}
+        >
+          <label className="flex flex-col gap-1">
+            <span className="text-sm font-medium text-zinc-800">メールアドレス</span>
+            <input
+              className="h-10 rounded-md border border-zinc-200 bg-white px-3 text-sm outline-none focus:ring-2 focus:ring-zinc-900/20"
+              type="email"
+              autoComplete="username"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </label>
+
+          <label className="flex flex-col gap-1">
+            <span className="text-sm font-medium text-zinc-800">パスワード</span>
+            <input
+              className="h-10 rounded-md border border-zinc-200 bg-white px-3 text-sm outline-none focus:ring-2 focus:ring-zinc-900/20"
+              type="password"
+              autoComplete="current-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </label>
+
+          {error ? <div className="text-sm text-red-600">{error}</div> : null}
+
+          <Button className="w-full" type="submit" disabled={loading}>
+            {loading ? "ログイン中..." : "ログイン"}
+          </Button>
+        </form>
+      </Card>
+    </div>
+  );
+}
+

--- a/frontend/src/app/admin/vocabularies/[id]/page.tsx
+++ b/frontend/src/app/admin/vocabularies/[id]/page.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import Link from "next/link";
+import { useParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { ApiError } from "@/lib/api/http";
+import { getAdminVocabulary, type AdminVocabulary } from "@/lib/api/admin/vocabularies";
+
+const ADMIN_TOKEN_KEY = "topik.admin.token";
+
+function Row({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-1 gap-1 sm:grid-cols-3 sm:gap-3">
+      <div className="text-sm font-medium text-zinc-700">{label}</div>
+      <div className="text-sm text-zinc-900 sm:col-span-2">{value}</div>
+    </div>
+  );
+}
+
+export default function AdminVocabularyDetailPage() {
+  const router = useRouter();
+  const params = useParams<{ id?: string }>();
+  const id = typeof params?.id === "string" ? params.id : "";
+
+  const [token, setToken] = useState<string | null>(null);
+  const [item, setItem] = useState<AdminVocabulary | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const t = window.localStorage.getItem(ADMIN_TOKEN_KEY);
+    if (!t) {
+      router.replace(`/admin/login?next=${encodeURIComponent(`/admin/vocabularies/${id}`)}`);
+      return;
+    }
+    setToken(t);
+  }, [id, router]);
+
+  useEffect(() => {
+    const run = async () => {
+      if (!token) return;
+      if (!id) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await getAdminVocabulary(token, id);
+        setItem(res.vocabulary);
+      } catch (e) {
+        if (e instanceof ApiError && (e.status === 401 || e.status === 419)) {
+          window.localStorage.removeItem(ADMIN_TOKEN_KEY);
+          router.replace(`/admin/login?next=${encodeURIComponent(`/admin/vocabularies/${id}`)}`);
+          return;
+        }
+        if (e instanceof ApiError) setError(e.message);
+        else setError("語彙の取得に失敗しました。");
+      } finally {
+        setLoading(false);
+      }
+    };
+    run().catch(() => undefined);
+  }, [id, router, token]);
+
+  return (
+    <div className="flex flex-1 justify-center bg-zinc-50 px-4 py-10">
+      <div className="w-full max-w-3xl space-y-4">
+        <div className="flex items-center justify-between">
+          <Link
+            className="inline-flex items-center gap-2 rounded-full bg-zinc-100 px-3 py-1.5 text-sm font-medium text-zinc-700 hover:bg-zinc-200"
+            href="/admin/vocabularies"
+          >
+            <span aria-hidden="true">←</span>
+            一覧に戻る
+          </Link>
+          <Link className="text-sm font-medium text-zinc-700 underline" href="/">
+            学習者画面へ
+          </Link>
+        </div>
+
+        <Card>
+          <div className="flex items-start justify-between gap-4">
+            <div className="min-w-0">
+              <h1 className="truncate text-2xl font-semibold text-zinc-900">
+                {item?.term ?? "語彙詳細"}
+              </h1>
+              <p className="mt-1 text-sm text-zinc-600">{item?.meaning_ja ?? ""}</p>
+            </div>
+            <div className="shrink-0 text-right text-xs text-zinc-500">
+              <div>{item?.status ?? ""}</div>
+              <div className="mt-1">{item?.created_at ?? ""}</div>
+            </div>
+          </div>
+
+          {error ? <div className="mt-4 text-sm text-red-600">{error}</div> : null}
+
+          <div className="mt-6 space-y-4">
+            <Row label="TOPIK" value={item ? `${item.level}級` : ""} />
+            <Row label="種別" value={item?.entry_type ?? ""} />
+            <Row label="品詞" value={item?.pos ?? ""} />
+            <Row label="ステータス" value={item?.status ?? ""} />
+            <Row label="音声URL" value={item?.audio_url ? <a className="underline" href={item.audio_url}>{item.audio_url}</a> : <span className="text-zinc-500">なし</span>} />
+          </div>
+
+          <div className="my-6 h-px bg-zinc-200" />
+
+          <div className="space-y-4 text-sm">
+            <div className="text-sm font-semibold text-zinc-900">例文</div>
+
+            {item?.example_sentence ? (
+              <div className="text-zinc-900 whitespace-pre-wrap">{item.example_sentence}</div>
+            ) : (
+              <div className="text-zinc-500">例文は未登録です。</div>
+            )}
+
+            {item?.example_translation_ja ? (
+              <div className="text-zinc-700 whitespace-pre-wrap">{item.example_translation_ja}</div>
+            ) : null}
+          </div>
+
+          <div className="mt-6 flex gap-3">
+            <Button
+              variant="secondary"
+              type="button"
+              disabled={loading}
+              onClick={() => {
+                if (!token) return;
+                if (!id) return;
+                setLoading(true);
+                getAdminVocabulary(token, id)
+                  .then((res) => setItem(res.vocabulary))
+                  .catch((e) => {
+                    if (e instanceof ApiError) setError(e.message);
+                    else setError("語彙の取得に失敗しました。");
+                  })
+                  .finally(() => setLoading(false));
+              }}
+            >
+              {loading ? "更新中..." : "更新"}
+            </Button>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/app/admin/vocabularies/[id]/page.tsx
+++ b/frontend/src/app/admin/vocabularies/[id]/page.tsx
@@ -89,7 +89,7 @@ export default function AdminVocabularyDetailPage() {
               <p className="mt-1 text-sm text-zinc-600">{item?.meaning_ja ?? ""}</p>
             </div>
             <div className="shrink-0 text-right text-xs text-zinc-500">
-              <div>{item?.status ?? ""}</div>
+              <div>{item?.status_label_ja ?? item?.status ?? ""}</div>
               <div className="mt-1">{item?.created_at ?? ""}</div>
             </div>
           </div>
@@ -97,11 +97,22 @@ export default function AdminVocabularyDetailPage() {
           {error ? <div className="mt-4 text-sm text-red-600">{error}</div> : null}
 
           <div className="mt-6 space-y-4">
-            <Row label="TOPIK" value={item ? `${item.level}級` : ""} />
-            <Row label="種別" value={item?.entry_type ?? ""} />
-            <Row label="品詞" value={item?.pos ?? ""} />
-            <Row label="ステータス" value={item?.status ?? ""} />
-            <Row label="音声URL" value={item?.audio_url ? <a className="underline" href={item.audio_url}>{item.audio_url}</a> : <span className="text-zinc-500">なし</span>} />
+            <Row label="TOPIK" value={item?.level_label_ja ?? (item ? `${item.level}級` : "")} />
+            <Row label="種別" value={item?.entry_type_label_ja ?? item?.entry_type ?? ""} />
+            <Row label="品詞" value={item?.pos_label_ja ?? item?.pos ?? ""} />
+            <Row label="ステータス" value={item?.status_label_ja ?? item?.status ?? ""} />
+            <Row
+              label="音声URL"
+              value={
+                item?.audio_url ? (
+                  <a className="underline" href={item.audio_url}>
+                    {item.audio_url}
+                  </a>
+                ) : (
+                  <span className="text-zinc-500">なし</span>
+                )
+              }
+            />
           </div>
 
           <div className="my-6 h-px bg-zinc-200" />

--- a/frontend/src/app/admin/vocabularies/page.tsx
+++ b/frontend/src/app/admin/vocabularies/page.tsx
@@ -102,7 +102,11 @@ export default function AdminVocabulariesPage() {
 
           <div className="mt-4 divide-y divide-zinc-200">
             {(items ?? []).map((v) => (
-              <div key={v.id} className="py-3 -mx-6 px-6">
+              <Link
+                key={v.id}
+                href={`/admin/vocabularies/${v.id}`}
+                className="block py-3 hover:bg-zinc-50 -mx-6 px-6"
+              >
                 <div className="flex items-start justify-between gap-4">
                   <div className="min-w-0">
                     <div className="truncate text-base font-medium text-zinc-900">{v.term}</div>
@@ -115,7 +119,7 @@ export default function AdminVocabulariesPage() {
                     </div>
                   </div>
                 </div>
-              </div>
+              </Link>
             ))}
 
             {!loading && items && items.length === 0 ? (

--- a/frontend/src/app/admin/vocabularies/page.tsx
+++ b/frontend/src/app/admin/vocabularies/page.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { ApiError } from "@/lib/api/http";
+import { logoutAdmin, meAdmin } from "@/lib/api/admin/auth";
+import { listAdminVocabularies, type AdminVocabulary } from "@/lib/api/admin/vocabularies";
+
+const ADMIN_TOKEN_KEY = "topik.admin.token";
+
+export default function AdminVocabulariesPage() {
+  const router = useRouter();
+  const [token, setToken] = useState<string | null>(null);
+  const [adminName, setAdminName] = useState<string>("");
+  const [items, setItems] = useState<AdminVocabulary[] | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const t = window.localStorage.getItem(ADMIN_TOKEN_KEY);
+    if (!t) {
+      router.replace(`/admin/login?next=${encodeURIComponent("/admin/vocabularies")}`);
+      return;
+    }
+    setToken(t);
+  }, [router]);
+
+  useEffect(() => {
+    const run = async () => {
+      if (!token) return;
+      setLoading(true);
+      setError(null);
+      try {
+        const [meRes, listRes] = await Promise.all([meAdmin(token), listAdminVocabularies(token)]);
+        setAdminName(meRes.admin.name);
+        setItems(listRes.vocabularies);
+      } catch (e) {
+        if (e instanceof ApiError && (e.status === 401 || e.status === 419)) {
+          window.localStorage.removeItem(ADMIN_TOKEN_KEY);
+          router.replace(`/admin/login?next=${encodeURIComponent("/admin/vocabularies")}`);
+          return;
+        }
+        if (e instanceof ApiError) setError(e.message);
+        else setError("語彙の取得に失敗しました。");
+      } finally {
+        setLoading(false);
+      }
+    };
+    run().catch(() => undefined);
+  }, [router, token]);
+
+  return (
+    <div className="flex flex-1 justify-center bg-zinc-50 px-4 py-10">
+      <div className="w-full max-w-5xl space-y-4">
+        <Card>
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <h1 className="text-2xl font-semibold text-zinc-900">管理: 語彙</h1>
+              <p className="mt-1 text-sm text-zinc-600">
+                {adminName ? `ログイン中: ${adminName}` : "管理者としてログイン中"}
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Link
+                className="rounded-md px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100"
+                href="/"
+              >
+                学習者画面へ
+              </Link>
+              <Button
+                variant="secondary"
+                type="button"
+                onClick={() => {
+                  if (!token) return;
+                  setLoading(true);
+                  logoutAdmin(token)
+                    .catch(() => undefined)
+                    .finally(() => {
+                      window.localStorage.removeItem(ADMIN_TOKEN_KEY);
+                      router.push("/admin/login");
+                    });
+                }}
+              >
+                ログアウト
+              </Button>
+            </div>
+          </div>
+        </Card>
+
+        <Card>
+          <div className="flex items-center justify-between">
+            <div className="text-sm text-zinc-600">
+              {loading ? "読み込み中..." : `件数: ${items?.length ?? 0}`}
+            </div>
+            {error ? <div className="text-sm text-red-600">{error}</div> : null}
+          </div>
+
+          <div className="mt-4 divide-y divide-zinc-200">
+            {(items ?? []).map((v) => (
+              <div key={v.id} className="py-3 -mx-6 px-6">
+                <div className="flex items-start justify-between gap-4">
+                  <div className="min-w-0">
+                    <div className="truncate text-base font-medium text-zinc-900">{v.term}</div>
+                    <div className="mt-1 truncate text-sm text-zinc-600">{v.meaning_ja}</div>
+                  </div>
+                  <div className="shrink-0 text-right text-xs text-zinc-500">
+                    <div>{v.level_label_ja ?? `${v.level}級`}</div>
+                    <div className="mt-1">
+                      {(v.entry_type_label_ja ?? v.entry_type) + " / " + (v.pos_label_ja ?? v.pos)}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+
+            {!loading && items && items.length === 0 ? (
+              <div className="py-8 text-center text-sm text-zinc-600">語彙がありません。</div>
+            ) : null}
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/nav/AppHeader.tsx
+++ b/frontend/src/components/nav/AppHeader.tsx
@@ -36,6 +36,11 @@ function NavLink({
 
 export function AppHeader() {
   const { state, logout } = useAuth();
+  const pathname = usePathname();
+
+  if (pathname?.startsWith("/admin")) {
+    return null;
+  }
 
   return (
     <header className="border-b border-zinc-200 bg-white">

--- a/frontend/src/lib/api/admin/auth.ts
+++ b/frontend/src/lib/api/admin/auth.ts
@@ -1,0 +1,33 @@
+import { apiFetch } from "../http";
+
+export type Admin = {
+  id: string;
+  name: string;
+  email: string;
+  created_at?: string;
+};
+
+export async function loginAdmin(input: {
+  email: string;
+  password: string;
+}): Promise<{ token: string; admin: Admin }> {
+  return apiFetch("/api/v1/admin/auth/login", {
+    method: "POST",
+    body: JSON.stringify(input),
+  });
+}
+
+export async function logoutAdmin(token: string): Promise<{ message: string }> {
+  return apiFetch("/api/v1/admin/auth/logout", {
+    method: "POST",
+    token,
+  });
+}
+
+export async function meAdmin(token: string): Promise<{ admin: Admin }> {
+  return apiFetch("/api/v1/admin/auth/me", {
+    method: "GET",
+    token,
+  });
+}
+

--- a/frontend/src/lib/api/admin/vocabularies.ts
+++ b/frontend/src/lib/api/admin/vocabularies.ts
@@ -14,6 +14,7 @@ export type AdminVocabulary = {
   example_translation_ja?: string | null;
   audio_url?: string | null;
   status?: string;
+  status_label_ja?: string;
   created_at?: string;
 };
 

--- a/frontend/src/lib/api/admin/vocabularies.ts
+++ b/frontend/src/lib/api/admin/vocabularies.ts
@@ -14,11 +14,22 @@ export type AdminVocabulary = {
   example_translation_ja?: string | null;
   audio_url?: string | null;
   status?: string;
+  created_at?: string;
 };
 
 export async function listAdminVocabularies(
   token: string
 ): Promise<{ vocabularies: AdminVocabulary[] }> {
   return apiFetch("/api/v1/admin/vocabularies", { method: "GET", token });
+}
+
+export async function getAdminVocabulary(
+  token: string,
+  id: string
+): Promise<{ vocabulary: AdminVocabulary }> {
+  return apiFetch(`/api/v1/admin/vocabularies/${encodeURIComponent(id)}`, {
+    method: "GET",
+    token,
+  });
 }
 

--- a/frontend/src/lib/api/admin/vocabularies.ts
+++ b/frontend/src/lib/api/admin/vocabularies.ts
@@ -1,0 +1,24 @@
+import { apiFetch } from "../http";
+
+export type AdminVocabulary = {
+  id: string;
+  term: string;
+  meaning_ja: string;
+  pos: string;
+  pos_label_ja?: string;
+  level: number;
+  level_label_ja?: string;
+  entry_type: string;
+  entry_type_label_ja?: string;
+  example_sentence?: string | null;
+  example_translation_ja?: string | null;
+  audio_url?: string | null;
+  status?: string;
+};
+
+export async function listAdminVocabularies(
+  token: string
+): Promise<{ vocabularies: AdminVocabulary[] }> {
+  return apiFetch("/api/v1/admin/vocabularies", { method: "GET", token });
+}
+


### PR DESCRIPTION
## 概要
管理者がブラウザから語彙を確認・管理していくための土台として、管理者ログインと語彙一覧画面を追加します。

## 変更内容
- `/admin/login` を追加し、`/api/v1/admin/auth/login` で取得したトークンを `localStorage(topik.admin.token)` に保存
- `/admin/vocabularies` を追加し、`/api/v1/admin/auth/me` と `/api/v1/admin/vocabularies` を管理者トークンで呼び出して一覧表示
- 学習者用ヘッダー (`AppHeader`) を `/admin` 配下では非表示にして、管理画面と分離

## テスト
- [x] `make test` 通過
- [ ] `make lint-backend` 通過
- [ ] 手動動作確認済み（確認内容: 管理者ログイン→語彙一覧表示→ログアウト）

## チェックリスト
- [ ] マイグレーションあり → `make migrate` を実行済み or 手順を本文に記載
- [x] `.env` やシークレットを含んでいない
- [ ] 関連するテストを追加・更新した

## 関連
なし

Made with [Cursor](https://cursor.com)