### PR TITLE
fix: Vercelビルドで/admin/loginが落ちる問題を修正

### DIFF
--- a/frontend/src/app/admin/login/page.tsx
+++ b/frontend/src/app/admin/login/page.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
@@ -12,6 +12,29 @@ import { loginAdmin } from "@/lib/api/admin/auth";
 const ADMIN_TOKEN_KEY = "topik.admin.token";
 
 export default function AdminLoginPage() {
+  return (
+    <Suspense fallback={<AdminLoginSkeleton />}>
+      <AdminLoginInner />
+    </Suspense>
+  );
+}
+
+function AdminLoginSkeleton() {
+  return (
+    <div className="flex flex-1 items-center justify-center bg-zinc-50 px-4 py-10">
+      <Card className="w-full max-w-md">
+        <div className="h-6 w-36 rounded bg-zinc-200" />
+        <div className="mt-6 space-y-4">
+          <div className="h-16 rounded bg-zinc-100" />
+          <div className="h-16 rounded bg-zinc-100" />
+          <div className="h-10 rounded bg-zinc-200" />
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function AdminLoginInner() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const nextPath = useMemo(() => searchParams.get("next") || "/admin/vocabularies", [searchParams]);


### PR DESCRIPTION
## Summary
- `/admin/login` で `useSearchParams()` を利用していたため、Vercel の静的生成（prerender）時に Suspense 未ラップエラーでビルドが失敗していた
- `useSearchParams()` を使うコンポーネントを `Suspense` で包む形に変更

## Test plan
- [ ] Vercel で `next build` が成功する（/admin/login の prerender で落ちない）
- [ ] `/admin/login?next=/admin/vocabularies` でログイン後に next へ遷移できる


Made with [Cursor](https://cursor.com)