### PR TITLE
fix: VercelフロントからAPIを叩けるようCORSを拡張

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -63,3 +63,7 @@ AWS_BUCKET=
 AWS_USE_PATH_STYLE_ENDPOINT=false
 
 VITE_APP_NAME="${APP_NAME}"
+
+# ブラウザから API を叩くフロント（Vercel 等）のオリジン。カンマ区切りで複数指定可。
+# 例: https://korean-topik-app.vercel.app,https://korean-topik-app-xxx.vercel.app
+# CORS_ALLOWED_ORIGINS=

--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -16,10 +16,13 @@ return [
 
     'allowed_methods' => ['*'],
 
-    'allowed_origins' => [
-        'http://localhost:3000',
-        'http://127.0.0.1:3000',
-    ],
+    'allowed_origins' => array_values(array_filter(array_merge(
+        [
+            'http://localhost:3000',
+            'http://127.0.0.1:3000',
+        ],
+        array_filter(array_map('trim', explode(',', (string) env('CORS_ALLOWED_ORIGINS', ''))))
+    ))),
 
     'allowed_origins_patterns' => [],
 

--- a/docs/deploy/railway-backend.md
+++ b/docs/deploy/railway-backend.md
@@ -32,6 +32,8 @@ Railway の Backend サービス設定で、**Root Directory / Working Directory
 - `LOG_CHANNEL`: `stderr`
 - `DB_CONNECTION`: `mysql`
 - `FRONTEND_URL`: Vercel の URL（例: `https://xxxx.vercel.app`）
+- `CORS_ALLOWED_ORIGINS`: Vercel のオリジン（**カンマ区切りで複数可**）。例: `https://korean-topik-app.vercel.app,https://korean-topik-app-git-release-v01-koshifutamis-projects.vercel.app`  
+  フロントを Vercel に置くと、ブラウザから API を叩くとき **CORS が必須**です。未設定だと `localhost:3000` のみ許可されるため、本番では必ず設定する。
 
 #### DB 接続（MySQL サービス変数の参照）
 


### PR DESCRIPTION
## Summary
- バックエンドの `config/cors.php` が `localhost:3000` のみ許可していたため、Vercel（`https://*.vercel.app`）からのブラウザ `fetch` が CORS でブロックされていた
- `CORS_ALLOWED_ORIGINS`（カンマ区切り）で本番・プレビュー用オリジンを追加可能にした
- Railway デプロイ手順に環境変数の説明を追記

## 運用（マージ後）
Railway の Backend に例として次を設定:
`CORS_ALLOWED_ORIGINS=https://<本番Vercel>.vercel.app,https://<プレビュー用URLが分かれば追加>`

## Test plan
- [x] `make lint-backend` / `make test`


Made with [Cursor](https://cursor.com)