### PR TITLE
feat: ブックマーク機能を追加

### DIFF
--- a/backend/app/Application/User/Bookmark/BookmarkVocabulary/BookmarkVocabularyInput.php
+++ b/backend/app/Application/User/Bookmark/BookmarkVocabulary/BookmarkVocabularyInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Bookmark\BookmarkVocabulary;
+
+final class BookmarkVocabularyInput
+{
+    public function __construct(
+        public readonly string $userId,
+        public readonly string $vocabularyId,
+    ) {}
+}

--- a/backend/app/Application/User/Bookmark/BookmarkVocabulary/BookmarkVocabularyUseCase.php
+++ b/backend/app/Application/User/Bookmark/BookmarkVocabulary/BookmarkVocabularyUseCase.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Bookmark\BookmarkVocabulary;
+
+use App\Domain\Bookmark\Entity\Bookmark;
+use App\Domain\Bookmark\Exception\BookmarkAlreadyExistsException;
+use App\Domain\Bookmark\Repository\BookmarkRepositoryInterface;
+use App\Domain\User\ValueObject\UserId;
+use App\Domain\Vocabulary\Exception\VocabularyNotFoundException;
+use App\Domain\Vocabulary\Repository\VocabularyRepositoryInterface;
+use App\Domain\Vocabulary\ValueObject\VocabularyId;
+use App\Domain\Vocabulary\ValueObject\VocabularyStatus;
+
+final class BookmarkVocabularyUseCase
+{
+    public function __construct(
+        private readonly BookmarkRepositoryInterface $bookmarkRepository,
+        private readonly VocabularyRepositoryInterface $vocabularyRepository,
+    ) {}
+
+    public function execute(BookmarkVocabularyInput $input): void
+    {
+        $userId = new UserId($input->userId);
+        $vocabularyId = new VocabularyId($input->vocabularyId);
+
+        $vocabulary = $this->vocabularyRepository->findByIdAndStatus($vocabularyId, VocabularyStatus::PUBLISHED);
+        if ($vocabulary === null) {
+            throw new VocabularyNotFoundException;
+        }
+
+        if ($this->bookmarkRepository->existsByUserIdAndVocabularyId($userId, $vocabularyId)) {
+            throw new BookmarkAlreadyExistsException;
+        }
+
+        $bookmark = Bookmark::create($userId, $vocabularyId);
+        $this->bookmarkRepository->save($bookmark);
+    }
+}

--- a/backend/app/Application/User/Bookmark/ListBookmarks/ListBookmarksInput.php
+++ b/backend/app/Application/User/Bookmark/ListBookmarks/ListBookmarksInput.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Bookmark\ListBookmarks;
+
+final class ListBookmarksInput
+{
+    public function __construct(
+        public readonly string $userId,
+    ) {}
+}

--- a/backend/app/Application/User/Bookmark/ListBookmarks/ListBookmarksOutput.php
+++ b/backend/app/Application/User/Bookmark/ListBookmarks/ListBookmarksOutput.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Bookmark\ListBookmarks;
+
+final class ListBookmarksOutput
+{
+    /**
+     * @param  array<ListBookmarksVocabulary>  $vocabularies
+     */
+    public function __construct(
+        public readonly array $vocabularies,
+    ) {}
+}

--- a/backend/app/Application/User/Bookmark/ListBookmarks/ListBookmarksUseCase.php
+++ b/backend/app/Application/User/Bookmark/ListBookmarks/ListBookmarksUseCase.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Bookmark\ListBookmarks;
+
+use App\Domain\Bookmark\Repository\BookmarkRepositoryInterface;
+use App\Domain\User\ValueObject\UserId;
+use App\Domain\Vocabulary\Repository\VocabularyRepositoryInterface;
+use App\Domain\Vocabulary\ValueObject\VocabularyStatus;
+
+final class ListBookmarksUseCase
+{
+    public function __construct(
+        private readonly BookmarkRepositoryInterface $bookmarkRepository,
+        private readonly VocabularyRepositoryInterface $vocabularyRepository,
+    ) {}
+
+    public function execute(ListBookmarksInput $input): ListBookmarksOutput
+    {
+        $userId = new UserId($input->userId);
+        $bookmarks = $this->bookmarkRepository->findByUserId($userId);
+
+        $vocabularies = [];
+        foreach ($bookmarks as $bookmark) {
+            $vocabulary = $this->vocabularyRepository->findByIdAndStatus(
+                $bookmark->vocabularyId(),
+                VocabularyStatus::PUBLISHED,
+            );
+
+            if ($vocabulary === null) {
+                continue;
+            }
+
+            $vocabularies[] = ListBookmarksVocabulary::fromDomain($vocabulary, $bookmark);
+        }
+
+        return new ListBookmarksOutput($vocabularies);
+    }
+}

--- a/backend/app/Application/User/Bookmark/ListBookmarks/ListBookmarksVocabulary.php
+++ b/backend/app/Application/User/Bookmark/ListBookmarks/ListBookmarksVocabulary.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Bookmark\ListBookmarks;
+
+use App\Domain\Bookmark\Entity\Bookmark;
+use App\Domain\Vocabulary\Entity\Vocabulary;
+
+final class ListBookmarksVocabulary
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $term,
+        public readonly string $meaningJa,
+        public readonly string $pos,
+        public readonly string $posLabelJa,
+        public readonly int $level,
+        public readonly string $levelLabelJa,
+        public readonly string $entryType,
+        public readonly string $entryTypeLabelJa,
+        public readonly ?string $exampleSentence,
+        public readonly ?string $exampleTranslationJa,
+        public readonly string $bookmarkedAt,
+    ) {}
+
+    public static function fromDomain(Vocabulary $vocabulary, Bookmark $bookmark): self
+    {
+        return new self(
+            id: $vocabulary->id()->value(),
+            term: $vocabulary->term()->value(),
+            meaningJa: $vocabulary->meaningJa()->value(),
+            pos: $vocabulary->pos()->value,
+            posLabelJa: $vocabulary->pos()->labelJa(),
+            level: $vocabulary->level()->value,
+            levelLabelJa: $vocabulary->level()->labelJa(),
+            entryType: $vocabulary->entryType()->value,
+            entryTypeLabelJa: $vocabulary->entryType()->labelJa(),
+            exampleSentence: $vocabulary->exampleSentence(),
+            exampleTranslationJa: $vocabulary->exampleTranslationJa(),
+            bookmarkedAt: $bookmark->createdAt()->format('Y-m-d\TH:i:s\Z'),
+        );
+    }
+}

--- a/backend/app/Application/User/Bookmark/UnbookmarkVocabulary/UnbookmarkVocabularyInput.php
+++ b/backend/app/Application/User/Bookmark/UnbookmarkVocabulary/UnbookmarkVocabularyInput.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Bookmark\UnbookmarkVocabulary;
+
+final class UnbookmarkVocabularyInput
+{
+    public function __construct(
+        public readonly string $userId,
+        public readonly string $vocabularyId,
+    ) {}
+}

--- a/backend/app/Application/User/Bookmark/UnbookmarkVocabulary/UnbookmarkVocabularyUseCase.php
+++ b/backend/app/Application/User/Bookmark/UnbookmarkVocabulary/UnbookmarkVocabularyUseCase.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Bookmark\UnbookmarkVocabulary;
+
+use App\Domain\Bookmark\Exception\BookmarkNotFoundException;
+use App\Domain\Bookmark\Repository\BookmarkRepositoryInterface;
+use App\Domain\User\ValueObject\UserId;
+use App\Domain\Vocabulary\ValueObject\VocabularyId;
+
+final class UnbookmarkVocabularyUseCase
+{
+    public function __construct(
+        private readonly BookmarkRepositoryInterface $bookmarkRepository,
+    ) {}
+
+    public function execute(UnbookmarkVocabularyInput $input): void
+    {
+        $userId = new UserId($input->userId);
+        $vocabularyId = new VocabularyId($input->vocabularyId);
+
+        if (! $this->bookmarkRepository->existsByUserIdAndVocabularyId($userId, $vocabularyId)) {
+            throw new BookmarkNotFoundException;
+        }
+
+        $this->bookmarkRepository->deleteByUserIdAndVocabularyId($userId, $vocabularyId);
+    }
+}

--- a/backend/app/Domain/Bookmark/Entity/Bookmark.php
+++ b/backend/app/Domain/Bookmark/Entity/Bookmark.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Bookmark\Entity;
+
+use App\Domain\Bookmark\ValueObject\BookmarkId;
+use App\Domain\User\ValueObject\UserId;
+use App\Domain\Vocabulary\ValueObject\VocabularyId;
+use DateTimeImmutable;
+
+final class Bookmark
+{
+    private function __construct(
+        private readonly BookmarkId $id,
+        private readonly UserId $userId,
+        private readonly VocabularyId $vocabularyId,
+        private readonly DateTimeImmutable $createdAt,
+    ) {}
+
+    public static function create(
+        UserId $userId,
+        VocabularyId $vocabularyId,
+    ): self {
+        return new self(
+            id: BookmarkId::generate(),
+            userId: $userId,
+            vocabularyId: $vocabularyId,
+            createdAt: new DateTimeImmutable,
+        );
+    }
+
+    public static function reconstruct(
+        BookmarkId $id,
+        UserId $userId,
+        VocabularyId $vocabularyId,
+        DateTimeImmutable $createdAt,
+    ): self {
+        return new self(
+            id: $id,
+            userId: $userId,
+            vocabularyId: $vocabularyId,
+            createdAt: $createdAt,
+        );
+    }
+
+    public function id(): BookmarkId
+    {
+        return $this->id;
+    }
+
+    public function userId(): UserId
+    {
+        return $this->userId;
+    }
+
+    public function vocabularyId(): VocabularyId
+    {
+        return $this->vocabularyId;
+    }
+
+    public function createdAt(): DateTimeImmutable
+    {
+        return $this->createdAt;
+    }
+}

--- a/backend/app/Domain/Bookmark/Exception/BookmarkAlreadyExistsException.php
+++ b/backend/app/Domain/Bookmark/Exception/BookmarkAlreadyExistsException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Bookmark\Exception;
+
+use RuntimeException;
+
+final class BookmarkAlreadyExistsException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('この語彙は既にブックマーク済みです。');
+    }
+}

--- a/backend/app/Domain/Bookmark/Exception/BookmarkNotFoundException.php
+++ b/backend/app/Domain/Bookmark/Exception/BookmarkNotFoundException.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Bookmark\Exception;
+
+use RuntimeException;
+
+final class BookmarkNotFoundException extends RuntimeException
+{
+    public function __construct()
+    {
+        parent::__construct('ブックマークが見つかりません。');
+    }
+}

--- a/backend/app/Domain/Bookmark/Repository/BookmarkRepositoryInterface.php
+++ b/backend/app/Domain/Bookmark/Repository/BookmarkRepositoryInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Bookmark\Repository;
+
+use App\Domain\Bookmark\Entity\Bookmark;
+use App\Domain\User\ValueObject\UserId;
+use App\Domain\Vocabulary\ValueObject\VocabularyId;
+
+interface BookmarkRepositoryInterface
+{
+    /** @return Bookmark[] */
+    public function findByUserId(UserId $userId): array;
+
+    public function existsByUserIdAndVocabularyId(UserId $userId, VocabularyId $vocabularyId): bool;
+
+    public function save(Bookmark $bookmark): void;
+
+    public function deleteByUserIdAndVocabularyId(UserId $userId, VocabularyId $vocabularyId): void;
+}

--- a/backend/app/Domain/Bookmark/ValueObject/BookmarkId.php
+++ b/backend/app/Domain/Bookmark/ValueObject/BookmarkId.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Bookmark\ValueObject;
+
+use Illuminate\Support\Str;
+use InvalidArgumentException;
+
+final class BookmarkId
+{
+    public function __construct(private readonly string $value)
+    {
+        if (! preg_match('/^[0-9A-HJKMNP-TV-Z]{26}$/i', $value)) {
+            throw new InvalidArgumentException("Invalid ULID format: {$value}");
+        }
+    }
+
+    public static function generate(): self
+    {
+        return new self((string) Str::ulid());
+    }
+
+    public function value(): string
+    {
+        return $this->value;
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->value === $other->value;
+    }
+}

--- a/backend/app/Http/Controllers/Api/V1/User/BookmarkController.php
+++ b/backend/app/Http/Controllers/Api/V1/User/BookmarkController.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\User;
+
+use App\Application\User\Bookmark\BookmarkVocabulary\BookmarkVocabularyInput;
+use App\Application\User\Bookmark\BookmarkVocabulary\BookmarkVocabularyUseCase;
+use App\Application\User\Bookmark\ListBookmarks\ListBookmarksInput;
+use App\Application\User\Bookmark\ListBookmarks\ListBookmarksUseCase;
+use App\Application\User\Bookmark\UnbookmarkVocabulary\UnbookmarkVocabularyInput;
+use App\Application\User\Bookmark\UnbookmarkVocabulary\UnbookmarkVocabularyUseCase;
+use App\Domain\Bookmark\Exception\BookmarkAlreadyExistsException;
+use App\Domain\Bookmark\Exception\BookmarkNotFoundException;
+use App\Domain\Vocabulary\Exception\VocabularyNotFoundException;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\V1\User\Bookmark\BookmarkRequest;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class BookmarkController extends Controller
+{
+    public function __construct(
+        private readonly ListBookmarksUseCase $listBookmarks,
+        private readonly BookmarkVocabularyUseCase $bookmarkVocabulary,
+        private readonly UnbookmarkVocabularyUseCase $unbookmarkVocabulary,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $output = $this->listBookmarks->execute(new ListBookmarksInput(
+            userId: (string) $request->user()?->getAuthIdentifier(),
+        ));
+
+        return response()->json([
+            'bookmarks' => array_map(static fn ($v) => [
+                'id' => $v->id,
+                'term' => $v->term,
+                'meaning_ja' => $v->meaningJa,
+                'pos' => $v->pos,
+                'pos_label_ja' => $v->posLabelJa,
+                'level' => $v->level,
+                'level_label_ja' => $v->levelLabelJa,
+                'entry_type' => $v->entryType,
+                'entry_type_label_ja' => $v->entryTypeLabelJa,
+                'example_sentence' => $v->exampleSentence,
+                'example_translation_ja' => $v->exampleTranslationJa,
+                'bookmarked_at' => $v->bookmarkedAt,
+            ], $output->vocabularies),
+        ]);
+    }
+
+    public function store(BookmarkRequest $request): JsonResponse
+    {
+        try {
+            $this->bookmarkVocabulary->execute(new BookmarkVocabularyInput(
+                userId: (string) $request->user()?->getAuthIdentifier(),
+                vocabularyId: (string) $request->input('vocabulary_id'),
+            ));
+
+            return response()->json(['message' => 'ブックマークに追加しました。'], 201);
+        } catch (VocabularyNotFoundException $e) {
+            return response()->json(['message' => $e->getMessage()], 404);
+        } catch (BookmarkAlreadyExistsException $e) {
+            return response()->json(['message' => $e->getMessage()], 409);
+        }
+    }
+
+    public function destroy(Request $request, string $vocabularyId): JsonResponse
+    {
+        try {
+            $this->unbookmarkVocabulary->execute(new UnbookmarkVocabularyInput(
+                userId: (string) $request->user()?->getAuthIdentifier(),
+                vocabularyId: $vocabularyId,
+            ));
+
+            return response()->json(['message' => 'ブックマークを削除しました。']);
+        } catch (BookmarkNotFoundException $e) {
+            return response()->json(['message' => $e->getMessage()], 404);
+        }
+    }
+}

--- a/backend/app/Http/Requests/Api/V1/User/Bookmark/BookmarkRequest.php
+++ b/backend/app/Http/Requests/Api/V1/User/Bookmark/BookmarkRequest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace App\Http\Requests\Api\V1\User\Bookmark;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class BookmarkRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'vocabulary_id' => ['required', 'string'],
+        ];
+    }
+}

--- a/backend/app/Infrastructure/Bookmark/Repository/BookmarkMapper.php
+++ b/backend/app/Infrastructure/Bookmark/Repository/BookmarkMapper.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Bookmark\Repository;
+
+use App\Domain\Bookmark\Entity\Bookmark as DomainBookmark;
+use App\Domain\Bookmark\ValueObject\BookmarkId;
+use App\Domain\User\ValueObject\UserId;
+use App\Domain\Vocabulary\ValueObject\VocabularyId;
+use App\Models\Bookmark as EloquentBookmark;
+use DateTimeImmutable;
+
+final class BookmarkMapper
+{
+    public static function toDomain(EloquentBookmark $model): DomainBookmark
+    {
+        return DomainBookmark::reconstruct(
+            id: new BookmarkId((string) $model->id),
+            userId: new UserId((string) $model->user_id),
+            vocabularyId: new VocabularyId((string) $model->vocabulary_id),
+            createdAt: new DateTimeImmutable($model->created_at?->toISOString() ?? 'now'),
+        );
+    }
+}

--- a/backend/app/Infrastructure/Bookmark/Repository/EloquentBookmarkRepository.php
+++ b/backend/app/Infrastructure/Bookmark/Repository/EloquentBookmarkRepository.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Bookmark\Repository;
+
+use App\Domain\Bookmark\Entity\Bookmark as DomainBookmark;
+use App\Domain\Bookmark\Repository\BookmarkRepositoryInterface;
+use App\Domain\User\ValueObject\UserId;
+use App\Domain\Vocabulary\ValueObject\VocabularyId;
+use App\Models\Bookmark as EloquentBookmark;
+
+final class EloquentBookmarkRepository implements BookmarkRepositoryInterface
+{
+    public function findByUserId(UserId $userId): array
+    {
+        return EloquentBookmark::query()
+            ->where('user_id', $userId->value())
+            ->orderBy('created_at', 'desc')
+            ->get()
+            ->map(static fn (EloquentBookmark $m): DomainBookmark => BookmarkMapper::toDomain($m))
+            ->all();
+    }
+
+    public function existsByUserIdAndVocabularyId(UserId $userId, VocabularyId $vocabularyId): bool
+    {
+        return EloquentBookmark::query()
+            ->where('user_id', $userId->value())
+            ->where('vocabulary_id', $vocabularyId->value())
+            ->exists();
+    }
+
+    public function save(DomainBookmark $bookmark): void
+    {
+        EloquentBookmark::query()->create([
+            'id' => $bookmark->id()->value(),
+            'user_id' => $bookmark->userId()->value(),
+            'vocabulary_id' => $bookmark->vocabularyId()->value(),
+        ]);
+    }
+
+    public function deleteByUserIdAndVocabularyId(UserId $userId, VocabularyId $vocabularyId): void
+    {
+        EloquentBookmark::query()
+            ->where('user_id', $userId->value())
+            ->where('vocabulary_id', $vocabularyId->value())
+            ->delete();
+    }
+}

--- a/backend/app/Models/Bookmark.php
+++ b/backend/app/Models/Bookmark.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+#[Fillable([
+    'id',
+    'user_id',
+    'vocabulary_id',
+])]
+class Bookmark extends Model
+{
+    use HasFactory, HasUlids;
+
+    protected $table = 'bookmarks';
+
+    protected $keyType = 'string';
+
+    public $incrementing = false;
+
+    public function vocabulary(): BelongsTo
+    {
+        return $this->belongsTo(Vocabulary::class);
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -12,10 +12,12 @@ use App\Application\User\Auth\LoginUser\LoginUserUseCase;
 use App\Application\User\Auth\LogoutUser\LogoutUserUseCase;
 use App\Application\User\Auth\RegisterUser\RegisterUserUseCase;
 use App\Domain\Admin\Repository\AdminRepositoryInterface;
+use App\Domain\Bookmark\Repository\BookmarkRepositoryInterface;
 use App\Domain\User\Repository\UserRepositoryInterface;
 use App\Domain\Vocabulary\Repository\VocabularyRepositoryInterface;
 use App\Infrastructure\Admin\Repository\EloquentAdminRepository;
 use App\Infrastructure\Admin\Token\SanctumAdminTokenService;
+use App\Infrastructure\Bookmark\Repository\EloquentBookmarkRepository;
 use App\Infrastructure\Shared\Password\BcryptPasswordHasher;
 use App\Infrastructure\User\Repository\EloquentUserRepository;
 use App\Infrastructure\User\Token\SanctumUserTokenService;
@@ -32,6 +34,7 @@ class AppServiceProvider extends ServiceProvider
         $this->app->bind(UserRepositoryInterface::class, EloquentUserRepository::class);
         $this->app->bind(AdminRepositoryInterface::class, EloquentAdminRepository::class);
         $this->app->bind(VocabularyRepositoryInterface::class, EloquentVocabularyRepository::class);
+        $this->app->bind(BookmarkRepositoryInterface::class, EloquentBookmarkRepository::class);
         $this->app->bind(PasswordHasherInterface::class, BcryptPasswordHasher::class);
 
         $this->app->when([

--- a/backend/database/migrations/2026_04_11_000001_create_bookmarks_table.php
+++ b/backend/database/migrations/2026_04_11_000001_create_bookmarks_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('bookmarks', function (Blueprint $table): void {
+            $table->ulid('id')->primary();
+
+            $table->ulid('user_id');
+            $table->ulid('vocabulary_id');
+
+            $table->timestamps();
+
+            $table->unique(['user_id', 'vocabulary_id']);
+
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->foreign('vocabulary_id')->references('id')->on('vocabularies')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('bookmarks');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,6 +3,7 @@
 use App\Http\Controllers\Api\V1\Admin\Auth\AdminAuthController;
 use App\Http\Controllers\Api\V1\Admin\Vocabulary\VocabularyController;
 use App\Http\Controllers\Api\V1\Auth\UserAuthController;
+use App\Http\Controllers\Api\V1\User\BookmarkController;
 use App\Http\Controllers\Api\V1\Vocabulary\VocabularyController as UserVocabularyController;
 use Illuminate\Support\Facades\Route;
 
@@ -20,6 +21,12 @@ Route::prefix('v1')->group(function (): void {
     // Public: allow guest to browse published vocabularies.
     Route::get('/vocabularies', [UserVocabularyController::class, 'index']);
     Route::get('/vocabularies/{id}', [UserVocabularyController::class, 'show']);
+
+    Route::middleware('auth:sanctum')->group(function (): void {
+        Route::get('/bookmarks', [BookmarkController::class, 'index']);
+        Route::post('/bookmarks', [BookmarkController::class, 'store']);
+        Route::delete('/bookmarks/{vocabularyId}', [BookmarkController::class, 'destroy']);
+    });
 
     Route::prefix('admin/auth')->group(function (): void {
         Route::post('/login', [AdminAuthController::class, 'login']);

--- a/backend/tests/Feature/User/BookmarkTest.php
+++ b/backend/tests/Feature/User/BookmarkTest.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Tests\Feature\User;
+
+use App\Models\Bookmark;
+use App\Models\User;
+use App\Models\Vocabulary;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class BookmarkTest extends TestCase
+{
+    private function createUser(string $email = 'bookmark-user@example.com'): User
+    {
+        return User::query()->create([
+            'name' => 'Taro',
+            'email' => $email,
+            'password' => Hash::make('password123'),
+        ]);
+    }
+
+    private function authHeader(User $user): array
+    {
+        $token = $user->createToken('user')->plainTextToken;
+
+        return ['Authorization' => "Bearer {$token}", 'Accept' => 'application/json'];
+    }
+
+    private function createPublishedVocabulary(string $term = '먹다'): Vocabulary
+    {
+        return Vocabulary::query()->create([
+            'term' => $term,
+            'meaning_ja' => '食べる',
+            'pos' => 'verb',
+            'level' => 1,
+            'entry_type' => 'word',
+            'status' => 'published',
+        ]);
+    }
+
+    public function test_index_returns_200_with_bookmarked_vocabularies(): void
+    {
+        $user = $this->createUser();
+        $vocabulary = $this->createPublishedVocabulary();
+
+        Bookmark::query()->create([
+            'user_id' => $user->id,
+            'vocabulary_id' => $vocabulary->id,
+        ]);
+
+        $res = $this->getJson('/api/v1/bookmarks', $this->authHeader($user));
+
+        $res->assertOk();
+        $this->assertCount(1, $res->json('bookmarks'));
+        $res->assertJsonStructure([
+            'bookmarks' => [[
+                'id',
+                'term',
+                'meaning_ja',
+                'pos',
+                'pos_label_ja',
+                'level',
+                'level_label_ja',
+                'entry_type',
+                'entry_type_label_ja',
+                'example_sentence',
+                'example_translation_ja',
+                'bookmarked_at',
+            ]],
+        ]);
+        $this->assertSame('먹다', $res->json('bookmarks.0.term'));
+    }
+
+    public function test_store_returns_201_on_success(): void
+    {
+        $user = $this->createUser();
+        $vocabulary = $this->createPublishedVocabulary();
+
+        $res = $this->postJson('/api/v1/bookmarks', [
+            'vocabulary_id' => $vocabulary->id,
+        ], $this->authHeader($user));
+
+        $res->assertCreated();
+        $this->assertDatabaseHas('bookmarks', [
+            'user_id' => $user->id,
+            'vocabulary_id' => $vocabulary->id,
+        ]);
+    }
+
+    public function test_store_returns_409_when_already_bookmarked(): void
+    {
+        $user = $this->createUser();
+        $vocabulary = $this->createPublishedVocabulary();
+
+        Bookmark::query()->create([
+            'user_id' => $user->id,
+            'vocabulary_id' => $vocabulary->id,
+        ]);
+
+        $res = $this->postJson('/api/v1/bookmarks', [
+            'vocabulary_id' => $vocabulary->id,
+        ], $this->authHeader($user));
+
+        $res->assertStatus(409);
+    }
+
+    public function test_store_returns_404_for_nonexistent_vocabulary(): void
+    {
+        $user = $this->createUser();
+
+        $res = $this->postJson('/api/v1/bookmarks', [
+            'vocabulary_id' => '01ARZ3NDEKTSV4RRFFQ69G5FAV',
+        ], $this->authHeader($user));
+
+        $res->assertNotFound();
+    }
+
+    public function test_destroy_returns_200_on_success(): void
+    {
+        $user = $this->createUser();
+        $vocabulary = $this->createPublishedVocabulary();
+
+        Bookmark::query()->create([
+            'user_id' => $user->id,
+            'vocabulary_id' => $vocabulary->id,
+        ]);
+
+        $res = $this->deleteJson("/api/v1/bookmarks/{$vocabulary->id}", [], $this->authHeader($user));
+
+        $res->assertOk();
+        $this->assertDatabaseMissing('bookmarks', [
+            'user_id' => $user->id,
+            'vocabulary_id' => $vocabulary->id,
+        ]);
+    }
+
+    public function test_destroy_returns_404_when_not_bookmarked(): void
+    {
+        $user = $this->createUser();
+        $vocabulary = $this->createPublishedVocabulary();
+
+        $res = $this->deleteJson("/api/v1/bookmarks/{$vocabulary->id}", [], $this->authHeader($user));
+
+        $res->assertNotFound();
+    }
+
+    public function test_unauthenticated_user_cannot_access_bookmarks(): void
+    {
+        $res = $this->getJson('/api/v1/bookmarks', ['Accept' => 'application/json']);
+        $res->assertUnauthorized();
+    }
+}


### PR DESCRIPTION
## 概要

語彙をブックマーク登録・解除・一覧表示できる機能を追加。
バックエンドは Clean Architecture + DDD、フロントエンドは既存パターンに合わせて実装した。
あわせて PHP ビルトインサーバーの起動コマンドの誤りを修正し、CORS が正常に動作するようにした。

## 変更内容

**バックエンド**
- Domain: `BookmarkId` VO・`Bookmark` Entity・`BookmarkRepositoryInterface`・例外クラス 2 種
- Application: 追加 / 削除 / 一覧 の各 UseCase と Input/Output DTO
- Infrastructure: Eloquent モデル・マイグレーション (`bookmarks` テーブル)・Mapper・Repository
- Interface: `BookmarkController` (GET/POST/DELETE)・`BookmarkRequest`
- ルート: `auth:sanctum` 配下に `/api/v1/bookmarks` を追加
- DI: `AppServiceProvider` に `BookmarkRepositoryInterface` バインドを追加

**フロントエンド**
- `src/lib/api/bookmarks.ts`: 一覧取得・追加・削除の API クライアント
- `src/app/bookmarks/page.tsx`: ブックマーク一覧ページ（未ログイン時はログイン促進）
- `src/app/vocabularies/[id]/page.tsx`: 語彙詳細に 🏷️/🔖 ブックマークトグルボタン追加（ハングルラベル）
- `src/components/nav/AppHeader.tsx`: ログイン中のみ「ブックマーク」ナビリンクを表示

**バグ修正**
- `docker-compose.yml`: `php artisan serve` → `php -S 0.0.0.0:8000 -t /var/www/html/public` に変更し CORS ヘッダーが返らない問題を修正

## テスト

- [x] `make test` 通過（36 テスト、130 アサーション）
- [x] `make lint-backend` 通過
- [x] ブラウザで動作確認済み（語彙一覧表示・ブックマーク追加・削除・一覧ページ）

## チェックリスト

- [x] マイグレーションあり → `make migrate` を実行すること（`2026_04_11_000001_create_bookmarks_table`）
- [x] `.env` やシークレットを含んでいない
- [x] 関連するテストを追加・更新した（`tests/Feature/User/BookmarkTest.php` — 7 ケース）

## 関連

なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)