### PR TITLE
feat: ブックマーク機能のフロントエンド実装と不具合修正

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "frontend",
       "runtimeExecutable": "docker",
       "runtimeArgs": ["compose", "up", "frontend"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": false
     },
     {
       "name": "backend",
@@ -17,7 +18,8 @@
       "name": "all",
       "runtimeExecutable": "docker",
       "runtimeArgs": ["compose", "up"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": false
     }
   ]
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       sh -c "composer install --no-interaction &&
              php artisan key:generate --force &&
              php artisan migrate --force &&
-             php artisan serve --host=0.0.0.0 --port=8000"
+             php -S 0.0.0.0:8000 -t /var/www/html/public"
 
   frontend:
     build:

--- a/frontend/src/app/bookmarks/page.tsx
+++ b/frontend/src/app/bookmarks/page.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+
+import { useAuth } from "@/components/auth/AuthProvider";
+import { Button } from "@/components/ui/Button";
+import { Card } from "@/components/ui/Card";
+import { Chip } from "@/components/ui/Chip";
+import { Section } from "@/components/ui/Section";
+import { Skeleton } from "@/components/ui/Skeleton";
+import {
+  listBookmarks,
+  removeBookmark,
+  type BookmarkVocabulary,
+} from "@/lib/api/bookmarks";
+import { ApiError } from "@/lib/api/http";
+
+function posKo(pos: string): string {
+  switch (pos) {
+    case "noun":
+      return "명사";
+    case "verb":
+      return "동사";
+    case "adj":
+      return "형용사";
+    case "adv":
+      return "부사";
+    case "particle":
+      return "조사";
+    case "determiner":
+      return "관형사";
+    case "pronoun":
+      return "대명사";
+    case "interjection":
+      return "감탄사";
+    default:
+      return "기타";
+  }
+}
+
+function entryTypeKo(t: string): string {
+  switch (t) {
+    case "word":
+      return "단어";
+    case "phrase":
+      return "숙어";
+    case "idiom":
+      return "관용구";
+    default:
+      return "";
+  }
+}
+
+export default function BookmarksPage() {
+  const { state, refreshMe } = useAuth();
+  const [items, setItems] = useState<BookmarkVocabulary[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [removing, setRemoving] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (state.status === "loading") {
+      refreshMe().catch(() => undefined);
+    }
+  }, [refreshMe, state.status]);
+
+  useEffect(() => {
+    if (state.status !== "authed") return;
+    const run = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await listBookmarks(state.token);
+        setItems(res.bookmarks);
+      } catch (e) {
+        if (e instanceof ApiError) setError(e.message);
+        else setError("ブックマークの取得に失敗しました。");
+      } finally {
+        setLoading(false);
+      }
+    };
+    run().catch(() => undefined);
+  }, [state]);
+
+  const handleRemove = async (vocabularyId: string) => {
+    if (state.status !== "authed") return;
+    setRemoving(vocabularyId);
+    try {
+      await removeBookmark(state.token, vocabularyId);
+      setItems((prev) => (prev ? prev.filter((v) => v.id !== vocabularyId) : prev));
+    } catch (e) {
+      if (e instanceof ApiError) setError(e.message);
+      else setError("ブックマークの削除に失敗しました。");
+    } finally {
+      setRemoving(null);
+    }
+  };
+
+  if (state.status === "loading") {
+    return (
+      <div className="flex flex-1 items-center justify-center bg-gradient-to-b from-sky-600 via-teal-500 to-cyan-700 px-4 py-10 text-white">
+        <div className="text-sm text-white/80">読み込み中...</div>
+      </div>
+    );
+  }
+
+  if (state.status === "guest") {
+    return (
+      <div className="flex flex-1 items-center justify-center bg-gradient-to-b from-sky-600 via-teal-500 to-cyan-700 px-4 py-10 text-white">
+        <Card className="w-full max-w-md border-white/10 bg-white/10 text-white backdrop-blur">
+          <h1 className="text-2xl font-extrabold tracking-tight text-white drop-shadow-sm">
+            未ログイン
+            <span className="ml-2 align-baseline text-base font-semibold text-white/85">
+              로그인 필요
+            </span>
+          </h1>
+          <p className="mt-2 text-sm text-white/80">
+            続けるには{" "}
+            <Link className="font-semibold underline" href="/login">
+              ログイン
+            </Link>
+            してください。
+          </p>
+        </Card>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-[calc(100vh-56px)] bg-gradient-to-b from-sky-600 via-teal-500 to-cyan-700 px-4 py-8 text-white">
+      <div className="mx-auto w-full max-w-5xl space-y-6">
+        <div className="flex flex-col gap-2">
+          <h1 className="text-3xl font-extrabold tracking-tight text-white drop-shadow-sm sm:text-4xl">
+            ブックマーク
+            <span className="ml-2 align-baseline text-lg font-semibold text-white/85">
+              북마크
+            </span>
+          </h1>
+          <p className="text-sm text-white/80">保存した語彙を確認できます。</p>
+        </div>
+
+        <Section
+          title="保存済み語彙"
+          subtitle="저장된 단어"
+          description={loading ? "読み込み中..." : `件数: ${items?.length ?? 0}`}
+          right={error ? <div className="text-sm font-medium text-red-200">{error}</div> : null}
+          headerClassName="rounded-2xl bg-white/10 px-4 py-3 ring-1 ring-white/10 backdrop-blur"
+          titleClassName="text-white drop-shadow-sm"
+          descriptionClassName="text-white/80"
+        >
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {loading
+              ? Array.from({ length: 6 }).map((_, i) => (
+                  <Card key={i} className="border-white/10 bg-white/10 p-5 text-white backdrop-blur">
+                    <Skeleton className="h-6 w-2/3" />
+                    <Skeleton className="mt-3 h-4 w-5/6" />
+                    <div className="mt-4 flex gap-2">
+                      <Skeleton className="h-7 w-16 rounded-full" />
+                      <Skeleton className="h-7 w-20 rounded-full" />
+                    </div>
+                  </Card>
+                ))
+              : (items ?? []).map((v, idx) => (
+                  <Card
+                    key={v.id}
+                    className={[
+                      "p-5",
+                      "bg-gradient-to-br",
+                      idx % 3 === 0 ? "from-violet-700/60 via-fuchsia-600/40 to-orange-500/50" : "",
+                      idx % 3 === 1 ? "from-sky-500/60 via-emerald-500/40 to-lime-400/40" : "",
+                      idx % 3 === 2 ? "from-orange-500/70 via-rose-500/40 to-violet-700/50" : "",
+                      "border-white/10 text-white backdrop-blur",
+                    ].join(" ")}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <Link href={`/vocabularies/${v.id}`} className="min-w-0 flex-1">
+                        <div className="truncate text-lg font-extrabold text-white hover:underline">
+                          {v.term}
+                        </div>
+                        <div className="mt-1 line-clamp-2 text-sm text-white/85">
+                          {v.meaning_ja}
+                        </div>
+                      </Link>
+                      <div className="shrink-0 text-right text-xs text-white/80">
+                        <div className="font-semibold">{v.level_label_ja}</div>
+                        <div className="mt-1">{v.pos_label_ja}</div>
+                      </div>
+                    </div>
+
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      <Chip type="button" selected disabled>
+                        {v.entry_type_label_ja}
+                        <span className="ml-1 text-[11px] font-semibold opacity-80">
+                          {entryTypeKo(v.entry_type)}
+                        </span>
+                      </Chip>
+                      <Chip type="button" selected disabled>
+                        {v.pos_label_ja}
+                        <span className="ml-1 text-[11px] font-semibold opacity-80">
+                          {posKo(v.pos)}
+                        </span>
+                      </Chip>
+                    </div>
+
+                    <div className="mt-4 flex items-center justify-between gap-2">
+                      <span className="text-xs text-white/60">
+                        {new Date(v.bookmarked_at).toLocaleDateString("ja-JP")}
+                      </span>
+                      <Button
+                        variant="secondary"
+                        type="button"
+                        disabled={removing === v.id}
+                        onClick={() => handleRemove(v.id)}
+                      >
+                        {removing === v.id ? "削除中..." : "削除"}
+                      </Button>
+                    </div>
+                  </Card>
+                ))}
+          </div>
+
+          {!loading && items && items.length === 0 ? (
+            <Card className="border-white/10 bg-white/10 text-center text-white backdrop-blur">
+              <div className="text-sm font-semibold text-white">
+                ブックマークがありません
+              </div>
+              <div className="mt-1 text-sm text-white/80">
+                語彙詳細ページからブックマークに追加できます。
+              </div>
+              <div className="mt-4">
+                <Link
+                  href="/vocabularies"
+                  className="inline-flex items-center gap-1 rounded-full bg-white/10 px-4 py-2 text-sm font-medium text-white ring-1 ring-white/25 hover:bg-white/15"
+                >
+                  語彙一覧へ
+                </Link>
+              </div>
+            </Card>
+          ) : null}
+        </Section>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/app/vocabularies/[id]/page.tsx
+++ b/frontend/src/app/vocabularies/[id]/page.tsx
@@ -10,6 +10,7 @@ import { Card } from "@/components/ui/Card";
 import { Chip } from "@/components/ui/Chip";
 import { Section } from "@/components/ui/Section";
 import { Skeleton } from "@/components/ui/Skeleton";
+import { addBookmark, listBookmarks, removeBookmark } from "@/lib/api/bookmarks";
 import { ApiError } from "@/lib/api/http";
 import { getVocabulary, type UserVocabularyDetail } from "@/lib/api/vocabularies";
 
@@ -56,6 +57,8 @@ export default function VocabularyDetailPage() {
   const [item, setItem] = useState<UserVocabularyDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
+  const [bookmarked, setBookmarked] = useState<boolean | null>(null);
+  const [bookmarkBusy, setBookmarkBusy] = useState(false);
 
   useEffect(() => {
     if (state.status === "loading") {
@@ -72,6 +75,12 @@ export default function VocabularyDetailPage() {
         const token = state.status === "authed" ? state.token : null;
         const res = await getVocabulary(token, id);
         setItem(res.vocabulary);
+        if (state.status === "authed") {
+          const bRes = await listBookmarks(state.token);
+          setBookmarked(bRes.bookmarks.some((b) => b.id === id));
+        } else {
+          setBookmarked(null);
+        }
       } catch (e) {
         if (e instanceof ApiError) setError(e.message);
         else setError("語彙の取得に失敗しました。");
@@ -81,6 +90,26 @@ export default function VocabularyDetailPage() {
     };
     run().catch(() => undefined);
   }, [id, state]);
+
+  const handleBookmarkToggle = async () => {
+    if (state.status !== "authed" || !id || bookmarkBusy) return;
+    setBookmarkBusy(true);
+    setError(null);
+    try {
+      if (bookmarked) {
+        await removeBookmark(state.token, id);
+        setBookmarked(false);
+      } else {
+        await addBookmark(state.token, id);
+        setBookmarked(true);
+      }
+    } catch (e) {
+      if (e instanceof ApiError) setError(e.message);
+      else setError("ブックマークの操作に失敗しました。");
+    } finally {
+      setBookmarkBusy(false);
+    }
+  };
 
   if (state.status === "loading") {
     return (
@@ -101,6 +130,27 @@ export default function VocabularyDetailPage() {
             <span aria-hidden="true">←</span>
             一覧に戻る
           </Link>
+          {state.status === "authed" && bookmarked !== null ? (
+            <button
+              type="button"
+              disabled={bookmarkBusy || loading}
+              onClick={handleBookmarkToggle}
+              className={[
+                "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium ring-1 transition-colors",
+                bookmarked
+                  ? "bg-white/20 text-white ring-white/30 hover:bg-white/30"
+                  : "bg-white/10 text-white/80 ring-white/25 hover:bg-white/15",
+                bookmarkBusy ? "opacity-60" : "",
+              ].join(" ")}
+            >
+              <span aria-hidden="true">{bookmarked ? "★" : "☆"}</span>
+              {bookmarkBusy
+                ? "..."
+                : bookmarked
+                  ? "保存済み"
+                  : "ブックマーク"}
+            </button>
+          ) : null}
         </div>
 
         <Card className="border-white/10 bg-white/10 text-white backdrop-blur">

--- a/frontend/src/app/vocabularies/[id]/page.tsx
+++ b/frontend/src/app/vocabularies/[id]/page.tsx
@@ -143,19 +143,9 @@ export default function VocabularyDetailPage() {
                 bookmarkBusy ? "opacity-60" : "",
               ].join(" ")}
             >
-              <svg
-                aria-hidden="true"
-                xmlns="http://www.w3.org/2000/svg"
-                viewBox="0 0 24 24"
-                className="h-4 w-4 shrink-0"
-                fill={bookmarked ? "currentColor" : "none"}
-                stroke="currentColor"
-                strokeWidth={2}
-                strokeLinecap="round"
-                strokeLinejoin="round"
-              >
-                <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
-              </svg>
+              <span aria-hidden="true" className="text-base leading-none">
+                {bookmarked ? "🔖" : "🏷️"}
+              </span>
               {bookmarkBusy
                 ? "저장 중..."
                 : bookmarked

--- a/frontend/src/app/vocabularies/[id]/page.tsx
+++ b/frontend/src/app/vocabularies/[id]/page.tsx
@@ -143,12 +143,24 @@ export default function VocabularyDetailPage() {
                 bookmarkBusy ? "opacity-60" : "",
               ].join(" ")}
             >
-              <span aria-hidden="true">{bookmarked ? "★" : "☆"}</span>
+              <svg
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                className="h-4 w-4 shrink-0"
+                fill={bookmarked ? "currentColor" : "none"}
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
+              </svg>
               {bookmarkBusy
-                ? "..."
+                ? "저장 중..."
                 : bookmarked
-                  ? "保存済み"
-                  : "ブックマーク"}
+                  ? "저장됨"
+                  : "북마크"}
             </button>
           ) : null}
         </div>

--- a/frontend/src/components/nav/AppHeader.tsx
+++ b/frontend/src/components/nav/AppHeader.tsx
@@ -50,6 +50,7 @@ export function AppHeader() {
 
   const isLearnerGlass =
     pathname?.startsWith("/vocabularies") ||
+    pathname?.startsWith("/bookmarks") ||
     pathname === "/login" ||
     pathname === "/register" ||
     pathname === "/me";
@@ -82,6 +83,9 @@ export function AppHeader() {
           </Link>
           <nav className="hidden items-center gap-1 sm:flex">
             <NavLink href="/vocabularies" label="語彙" tone={tone} />
+            {state.status === "authed" ? (
+              <NavLink href="/bookmarks" label="ブックマーク" tone={tone} />
+            ) : null}
             <NavLink href="/me" label="プロフィール" tone={tone} />
           </nav>
         </div>
@@ -132,6 +136,9 @@ export function AppHeader() {
       <div className="mx-auto w-full max-w-5xl px-4 pb-3 sm:hidden">
         <nav className="flex items-center gap-1">
           <NavLink href="/vocabularies" label="語彙" tone={tone} />
+          {state.status === "authed" ? (
+            <NavLink href="/bookmarks" label="ブックマーク" tone={tone} />
+          ) : null}
           <NavLink href="/me" label="プロフィール" tone={tone} />
         </nav>
       </div>

--- a/frontend/src/lib/api/bookmarks.ts
+++ b/frontend/src/lib/api/bookmarks.ts
@@ -1,0 +1,37 @@
+import { apiFetch } from "./http";
+
+export type BookmarkVocabulary = {
+  id: string;
+  term: string;
+  meaning_ja: string;
+  pos: string;
+  pos_label_ja: string;
+  level: number;
+  level_label_ja: string;
+  entry_type: string;
+  entry_type_label_ja: string;
+  example_sentence?: string | null;
+  example_translation_ja?: string | null;
+  bookmarked_at: string;
+};
+
+export async function listBookmarks(
+  token: string
+): Promise<{ bookmarks: BookmarkVocabulary[] }> {
+  return apiFetch("/api/v1/bookmarks", { method: "GET", token });
+}
+
+export async function addBookmark(token: string, vocabularyId: string): Promise<void> {
+  await apiFetch("/api/v1/bookmarks", {
+    method: "POST",
+    token,
+    body: JSON.stringify({ vocabulary_id: vocabularyId }),
+  });
+}
+
+export async function removeBookmark(token: string, vocabularyId: string): Promise<void> {
+  await apiFetch(`/api/v1/bookmarks/${encodeURIComponent(vocabularyId)}`, {
+    method: "DELETE",
+    token,
+  });
+}


### PR DESCRIPTION
## 概要

ブックマーク機能のフロントエンドを実装し、CORS が動作しない不具合を修正。
ブックマークボタンのアイコンはブックマーク型絵文字（🏷️/🔖）、ラベルはハングル表記。

## 変更内容

**フロントエンド**
- `src/lib/api/bookmarks.ts`: 一覧取得・追加・削除の API クライアント
- `src/app/bookmarks/page.tsx`: ブックマーク一覧ページ（未ログイン時はログイン促進）
- `src/app/vocabularies/[id]/page.tsx`: 語彙詳細に 🏷️/🔖 ブックマークトグルボタン追加（ハングルラベル: 북마크 / 저장됨）
- `src/components/nav/AppHeader.tsx`: ログイン中のみ「ブックマーク」ナビリンクを表示

**バグ修正**
- `docker-compose.yml`: `php artisan serve` → `php -S 0.0.0.0:8000 -t /var/www/html/public` に変更し、CORS ヘッダーが返らない問題を修正

## テスト

- [x] `make test` 通過（36 テスト）
- [x] `make lint-backend` 通過
- [x] ブラウザで動作確認済み（語彙一覧・ブックマーク追加・削除・一覧ページ・ボタン絵文字）

## チェックリスト

- [ ] マイグレーションあり → なし（バックエンド PR #12 で適用済み）
- [x] `.env` やシークレットを含んでいない
- [x] 関連するテストはバックエンド PR #12 に含まれている

## 関連

KoshiFutami/korean-topik-app#12 のフロントエンド実装分

🤖 Generated with [Claude Code](https://claude.com/claude-code)