### PR TITLE
refactor: 語彙詳細から手動「更新」ボタンを削除

### DIFF
--- a/frontend/src/app/vocabularies/[id]/page.tsx
+++ b/frontend/src/app/vocabularies/[id]/page.tsx
@@ -5,7 +5,6 @@ import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
 
 import { useAuth } from "@/components/auth/AuthProvider";
-import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { Chip } from "@/components/ui/Chip";
 import { Section } from "@/components/ui/Section";
@@ -273,28 +272,6 @@ export default function VocabularyDetailPage() {
                   <div className="text-white/80">{item.example_translation_ja}</div>
                 </div>
               ) : null}
-            </div>
-
-            <div className="mt-6">
-              <Button
-                className="w-full sm:w-auto"
-                type="button"
-                disabled={loading}
-                onClick={() => {
-                  if (!id) return;
-                  setLoading(true);
-                  const token = state.status === "authed" ? state.token : null;
-                  getVocabulary(token, id)
-                    .then((res) => setItem(res.vocabulary))
-                    .catch((e) => {
-                      if (e instanceof ApiError) setError(e.message);
-                      else setError("語彙の取得に失敗しました。");
-                    })
-                    .finally(() => setLoading(false));
-                }}
-              >
-                {loading ? "更新中..." : "更新"}
-              </Button>
             </div>
           </Card>
         </Section>


### PR DESCRIPTION
## 概要

語彙詳細の例文セクションにあった「更新」は、マウント時・`id` / 認証状態変更時の `useEffect` で既に再取得しており冗長。ブックマーク操作後も語彙 JSON は変わらないため、UI を簡素化する。

## 変更内容

- 例文カード下の手動再取得ボタンと `Button` import を削除。

## テスト

- [x] `make test` 通過（**フロントのみのため未実行**／AGENTS の扱いに従う）
- [x] `make lint-backend` 通過（**PHP 変更なしのため未実行**）
- [x] 手動動作確認済み（確認内容: 対象ファイルの `eslint`）

## チェックリスト

- [x] マイグレーションなし
- [x] `.env` やシークレットを含んでいない
- [x] 関連するテストを追加・更新した（**変更なし**）

## 関連

なし

Made with [Cursor](https://cursor.com)