### PR TITLE
feat: 語彙一覧の軽量取得（compact）と仮想スクロール

### DIFF
--- a/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesCard.php
+++ b/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesCard.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\User\Vocabulary\ListVocabularies;
+
+use App\Domain\Vocabulary\ReadModel\VocabularyListCardReadModel;
+use App\Domain\Vocabulary\ValueObject\EntryType;
+use App\Domain\Vocabulary\ValueObject\PartOfSpeech;
+use App\Domain\Vocabulary\ValueObject\TopikLevel;
+
+/**
+ * 一覧カード用（例文・例文音声 URL を含めない）。
+ */
+final class ListVocabulariesCard
+{
+    public function __construct(
+        public readonly string $id,
+        public readonly string $term,
+        public readonly string $meaningJa,
+        public readonly string $pos,
+        public readonly string $posLabelJa,
+        public readonly int $level,
+        public readonly string $levelLabelJa,
+        public readonly string $entryType,
+        public readonly string $entryTypeLabelJa,
+        public readonly ?string $audioUrl,
+    ) {}
+
+    public static function fromReadModel(VocabularyListCardReadModel $row): self
+    {
+        $pos = PartOfSpeech::from($row->pos);
+        $level = TopikLevel::from($row->level);
+        $entryType = EntryType::from($row->entryType);
+
+        return new self(
+            id: $row->id,
+            term: $row->term,
+            meaningJa: $row->meaningJa,
+            pos: $row->pos,
+            posLabelJa: $pos->labelJa(),
+            level: $row->level,
+            levelLabelJa: $level->labelJa(),
+            entryType: $row->entryType,
+            entryTypeLabelJa: $entryType->labelJa(),
+            audioUrl: $row->audioUrl,
+        );
+    }
+}

--- a/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesInput.php
+++ b/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesInput.php
@@ -10,5 +10,7 @@ final class ListVocabulariesInput
         public readonly ?int $level = null,
         public readonly ?string $entryType = null,
         public readonly ?string $pos = null,
+        /** 一覧カード向けの軽量レスポンス（例文・例文音声を省き、DB も必要列のみ読む） */
+        public readonly bool $compactList = false,
     ) {}
 }

--- a/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesOutput.php
+++ b/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesOutput.php
@@ -7,7 +7,7 @@ namespace App\Application\User\Vocabulary\ListVocabularies;
 final class ListVocabulariesOutput
 {
     /**
-     * @param  array<int, ListVocabulariesVocabulary>  $vocabularies
+     * @param  array<int, ListVocabulariesVocabulary|ListVocabulariesCard>  $vocabularies
      */
     public function __construct(public readonly array $vocabularies) {}
 }

--- a/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesUseCase.php
+++ b/backend/app/Application/User/Vocabulary/ListVocabularies/ListVocabulariesUseCase.php
@@ -20,6 +20,22 @@ final class ListVocabulariesUseCase
         $entryType = $input->entryType !== null ? EntryType::from($input->entryType) : null;
         $pos = $input->pos !== null ? PartOfSpeech::from($input->pos) : null;
 
+        if ($input->compactList) {
+            $rows = $this->vocabularies->listCardsByStatus(
+                VocabularyStatus::PUBLISHED,
+                level: $level,
+                entryType: $entryType,
+                pos: $pos,
+            );
+
+            return new ListVocabulariesOutput(
+                vocabularies: array_map(
+                    static fn ($r) => ListVocabulariesCard::fromReadModel($r),
+                    $rows,
+                ),
+            );
+        }
+
         $items = $this->vocabularies->listByStatus(
             VocabularyStatus::PUBLISHED,
             level: $level,

--- a/backend/app/Domain/Vocabulary/ReadModel/VocabularyListCardReadModel.php
+++ b/backend/app/Domain/Vocabulary/ReadModel/VocabularyListCardReadModel.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Domain\Vocabulary\ReadModel;
+
+/**
+ * 一覧カード表示用の最小列（例文・例文音声は含めない）。
+ */
+final readonly class VocabularyListCardReadModel
+{
+    public function __construct(
+        public string $id,
+        public string $term,
+        public string $meaningJa,
+        public string $pos,
+        public int $level,
+        public string $entryType,
+        public ?string $audioUrl,
+    ) {}
+}

--- a/backend/app/Domain/Vocabulary/Repository/VocabularyRepositoryInterface.php
+++ b/backend/app/Domain/Vocabulary/Repository/VocabularyRepositoryInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Domain\Vocabulary\Repository;
 
 use App\Domain\Vocabulary\Entity\Vocabulary;
+use App\Domain\Vocabulary\ReadModel\VocabularyListCardReadModel;
 use App\Domain\Vocabulary\ValueObject\EntryType;
 use App\Domain\Vocabulary\ValueObject\MeaningJa;
 use App\Domain\Vocabulary\ValueObject\PartOfSpeech;
@@ -26,6 +27,18 @@ interface VocabularyRepositoryInterface
      * @return array<int, Vocabulary>
      */
     public function listByStatus(
+        VocabularyStatus $status,
+        ?TopikLevel $level = null,
+        ?EntryType $entryType = null,
+        ?PartOfSpeech $pos = null,
+    ): array;
+
+    /**
+     * 一覧カード向けに必要列のみ取得する（例文・例文音声 URL は読まない）。
+     *
+     * @return array<int, VocabularyListCardReadModel>
+     */
+    public function listCardsByStatus(
         VocabularyStatus $status,
         ?TopikLevel $level = null,
         ?EntryType $entryType = null,

--- a/backend/app/Http/Controllers/Api/V1/Vocabulary/VocabularyController.php
+++ b/backend/app/Http/Controllers/Api/V1/Vocabulary/VocabularyController.php
@@ -4,8 +4,10 @@ namespace App\Http\Controllers\Api\V1\Vocabulary;
 
 use App\Application\User\Vocabulary\GetVocabulary\GetVocabularyInput;
 use App\Application\User\Vocabulary\GetVocabulary\GetVocabularyUseCase;
+use App\Application\User\Vocabulary\ListVocabularies\ListVocabulariesCard;
 use App\Application\User\Vocabulary\ListVocabularies\ListVocabulariesInput;
 use App\Application\User\Vocabulary\ListVocabularies\ListVocabulariesUseCase;
+use App\Application\User\Vocabulary\ListVocabularies\ListVocabulariesVocabulary;
 use App\Domain\Vocabulary\Exception\ExampleSentenceMissingForAudioException;
 use App\Domain\Vocabulary\Exception\VocabularyNotFoundException;
 use App\Services\Vocabulary\EnsureVocabularyAudioService;
@@ -27,24 +29,43 @@ class VocabularyController
             level: $request->query('level') !== null ? (int) $request->query('level') : null,
             entryType: $request->query('entry_type'),
             pos: $request->query('pos'),
+            compactList: $request->boolean('compact'),
         ));
 
         return response()->json([
-            'vocabularies' => array_map(static fn ($v) => [
-                'id' => $v->id,
-                'term' => $v->term,
-                'meaning_ja' => $v->meaningJa,
-                'pos' => $v->pos,
-                'pos_label_ja' => $v->posLabelJa,
-                'level' => $v->level,
-                'level_label_ja' => $v->levelLabelJa,
-                'entry_type' => $v->entryType,
-                'entry_type_label_ja' => $v->entryTypeLabelJa,
-                'example_sentence' => $v->exampleSentence,
-                'example_translation_ja' => $v->exampleTranslationJa,
-                'audio_url' => VocabularyAudioUrl::resolveForHttp($v->audioUrl),
-                'example_audio_url' => VocabularyAudioUrl::resolveForHttp($v->exampleAudioUrl),
-            ], $output->vocabularies),
+            'vocabularies' => array_map(static function ($v) {
+                if ($v instanceof ListVocabulariesCard) {
+                    return [
+                        'id' => $v->id,
+                        'term' => $v->term,
+                        'meaning_ja' => $v->meaningJa,
+                        'pos' => $v->pos,
+                        'pos_label_ja' => $v->posLabelJa,
+                        'level' => $v->level,
+                        'level_label_ja' => $v->levelLabelJa,
+                        'entry_type' => $v->entryType,
+                        'entry_type_label_ja' => $v->entryTypeLabelJa,
+                        'audio_url' => VocabularyAudioUrl::resolveForHttp($v->audioUrl),
+                    ];
+                }
+
+                /** @var ListVocabulariesVocabulary $v */
+                return [
+                    'id' => $v->id,
+                    'term' => $v->term,
+                    'meaning_ja' => $v->meaningJa,
+                    'pos' => $v->pos,
+                    'pos_label_ja' => $v->posLabelJa,
+                    'level' => $v->level,
+                    'level_label_ja' => $v->levelLabelJa,
+                    'entry_type' => $v->entryType,
+                    'entry_type_label_ja' => $v->entryTypeLabelJa,
+                    'example_sentence' => $v->exampleSentence,
+                    'example_translation_ja' => $v->exampleTranslationJa,
+                    'audio_url' => VocabularyAudioUrl::resolveForHttp($v->audioUrl),
+                    'example_audio_url' => VocabularyAudioUrl::resolveForHttp($v->exampleAudioUrl),
+                ];
+            }, $output->vocabularies),
         ]);
     }
 

--- a/backend/app/Infrastructure/Vocabulary/Repository/EloquentVocabularyRepository.php
+++ b/backend/app/Infrastructure/Vocabulary/Repository/EloquentVocabularyRepository.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Infrastructure\Vocabulary\Repository;
 
 use App\Domain\Vocabulary\Entity\Vocabulary as DomainVocabulary;
+use App\Domain\Vocabulary\ReadModel\VocabularyListCardReadModel;
 use App\Domain\Vocabulary\Repository\VocabularyRepositoryInterface;
 use App\Domain\Vocabulary\ValueObject\EntryType;
 use App\Domain\Vocabulary\ValueObject\MeaningJa;
@@ -56,6 +57,49 @@ final class EloquentVocabularyRepository implements VocabularyRepositoryInterfac
             ->orderBy('term')
             ->get()
             ->map(static fn (EloquentVocabulary $m): DomainVocabulary => VocabularyMapper::toDomain($m))
+            ->all();
+    }
+
+    public function listCardsByStatus(
+        VocabularyStatus $status,
+        ?TopikLevel $level = null,
+        ?EntryType $entryType = null,
+        ?PartOfSpeech $pos = null,
+    ): array {
+        $q = EloquentVocabulary::query()
+            ->select([
+                'id',
+                'term',
+                'meaning_ja',
+                'pos',
+                'level',
+                'entry_type',
+                'audio_url',
+            ])
+            ->where('status', $status->value);
+
+        if ($level !== null) {
+            $q->where('level', $level->value);
+        }
+        if ($entryType !== null) {
+            $q->where('entry_type', $entryType->value);
+        }
+        if ($pos !== null) {
+            $q->where('pos', $pos->value);
+        }
+
+        return $q->orderBy('level')
+            ->orderBy('term')
+            ->get()
+            ->map(static fn (EloquentVocabulary $m): VocabularyListCardReadModel => new VocabularyListCardReadModel(
+                id: (string) $m->id,
+                term: (string) $m->term,
+                meaningJa: (string) $m->meaning_ja,
+                pos: (string) $m->pos,
+                level: (int) $m->level,
+                entryType: (string) $m->entry_type,
+                audioUrl: $m->audio_url !== null ? (string) $m->audio_url : null,
+            ))
             ->all();
     }
 

--- a/backend/tests/Feature/Vocabulary/User/VocabularyApiTest.php
+++ b/backend/tests/Feature/Vocabulary/User/VocabularyApiTest.php
@@ -121,4 +121,40 @@ class VocabularyApiTest extends TestCase
         $res = $this->getJson('/api/v1/vocabularies', ['Accept' => 'application/json']);
         $res->assertOk();
     }
+
+    public function test_index_compact_skips_example_fields(): void
+    {
+        Vocabulary::query()->create([
+            'term' => '읽다',
+            'meaning_ja' => '読む',
+            'pos' => 'verb',
+            'level' => 2,
+            'entry_type' => 'word',
+            'status' => 'published',
+            'example_sentence' => '책을 읽어요.',
+            'example_translation_ja' => '本を読みます。',
+        ]);
+
+        $res = $this->getJson('/api/v1/vocabularies?compact=1', ['Accept' => 'application/json']);
+
+        $res->assertOk();
+        $this->assertCount(1, $res->json('vocabularies'));
+        $res->assertJsonStructure([
+            'vocabularies' => [[
+                'id',
+                'term',
+                'meaning_ja',
+                'pos',
+                'pos_label_ja',
+                'level',
+                'level_label_ja',
+                'entry_type',
+                'entry_type_label_ja',
+                'audio_url',
+            ]],
+        ]);
+        $this->assertArrayNotHasKey('example_sentence', $res->json('vocabularies.0'));
+        $this->assertArrayNotHasKey('example_translation_ja', $res->json('vocabularies.0'));
+        $this->assertArrayNotHasKey('example_audio_url', $res->json('vocabularies.0'));
+    }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "app",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-virtual": "^3.13.23",
         "next": "16.2.3",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -1511,6 +1512,33 @@
         "@tailwindcss/oxide": "4.2.2",
         "postcss": "^8.5.6",
         "tailwindcss": "4.2.2"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.23.tgz",
+      "integrity": "sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.23"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.23",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.23.tgz",
+      "integrity": "sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@tybys/wasm-util": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "@tanstack/react-virtual": "^3.13.23",
     "next": "16.2.3",
     "react": "19.2.4",
     "react-dom": "19.2.4"

--- a/frontend/src/app/vocabularies/page.tsx
+++ b/frontend/src/app/vocabularies/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 
 import { useAuth } from "@/components/auth/AuthProvider";
@@ -9,7 +8,7 @@ import { Card } from "@/components/ui/Card";
 import { Chip } from "@/components/ui/Chip";
 import { Section } from "@/components/ui/Section";
 import { Skeleton } from "@/components/ui/Skeleton";
-import { VocabularyAudioPlayButton } from "@/components/vocabulary/VocabularyAudioPlayButton";
+import { VocabularyListVirtualGrid } from "@/components/vocabulary/VocabularyListVirtualGrid";
 import { ApiError } from "@/lib/api/http";
 import { listVocabularies, type UserVocabulary } from "@/lib/api/vocabularies";
 
@@ -44,42 +43,6 @@ const LEVEL_OPTIONS: Array<{ value: string; label: string }> = [
   ...[1, 2, 3, 4, 5, 6].map((n) => ({ value: String(n), label: `${n}級` })),
 ];
 
-function posKo(pos: string): string {
-  switch (pos) {
-    case "noun":
-      return "명사";
-    case "verb":
-      return "동사";
-    case "adj":
-      return "형용사";
-    case "adv":
-      return "부사";
-    case "particle":
-      return "조사";
-    case "determiner":
-      return "관형사";
-    case "pronoun":
-      return "대명사";
-    case "interjection":
-      return "감탄사";
-    default:
-      return "기타";
-  }
-}
-
-function entryTypeKo(t: string): string {
-  switch (t) {
-    case "word":
-      return "단어";
-    case "phrase":
-      return "숙어";
-    case "idiom":
-      return "관용구";
-    default:
-      return "";
-  }
-}
-
 export default function VocabulariesPage() {
   const { state, refreshMe } = useAuth();
   const [filters, setFilters] = useState<Filters>({ level: "", entry_type: "", pos: "" });
@@ -93,6 +56,7 @@ export default function VocabulariesPage() {
       level: Number.isFinite(level) ? level : undefined,
       entry_type: filters.entry_type || undefined,
       pos: filters.pos || undefined,
+      compact: true,
     };
   }, [filters]);
 
@@ -235,68 +199,22 @@ export default function VocabulariesPage() {
           titleClassName="text-white drop-shadow-sm"
           descriptionClassName="text-white/80"
         >
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {loading
-              ? Array.from({ length: 9 }).map((_, i) => (
-                  <Card key={i} className="border-white/10 bg-white/10 p-5 text-white backdrop-blur">
-                    <Skeleton className="h-6 w-2/3" />
-                    <Skeleton className="mt-3 h-4 w-5/6" />
-                    <div className="mt-4 flex gap-2">
-                      <Skeleton className="h-7 w-16 rounded-full" />
-                      <Skeleton className="h-7 w-20 rounded-full" />
-                    </div>
-                  </Card>
-                ))
-              : (items ?? []).map((v, idx) => (
-                  <Card
-                    key={v.id}
-                    className={[
-                      "group p-5 transition-transform hover:-translate-y-0.5 hover:shadow-md",
-                      "bg-gradient-to-br",
-                      idx % 3 === 0 ? "from-violet-700/60 via-fuchsia-600/40 to-orange-500/50" : "",
-                      idx % 3 === 1 ? "from-sky-500/60 via-emerald-500/40 to-lime-400/40" : "",
-                      idx % 3 === 2 ? "from-orange-500/70 via-rose-500/40 to-violet-700/50" : "",
-                      "border-white/10 text-white backdrop-blur",
-                    ].join(" ")}
-                  >
-                    <div className="flex items-start justify-between gap-3">
-                      <Link href={`/vocabularies/${v.id}`} className="min-w-0 flex-1 outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent">
-                        <div className="truncate text-lg font-extrabold text-white group-hover:underline">
-                          {v.term}
-                        </div>
-                        <div className="mt-1 line-clamp-2 text-sm text-white/85">{v.meaning_ja}</div>
-                      </Link>
-                      <div className="flex shrink-0 flex-col items-end gap-2">
-                        <div className="text-right text-xs text-white/80">
-                          <div className="font-semibold">{v.level_label_ja}</div>
-                          <div className="mt-1">{v.pos_label_ja}</div>
-                        </div>
-                        <VocabularyAudioPlayButton vocabularyId={v.id} initialAudioUrl={v.audio_url} />
-                      </div>
-                    </div>
-
-                    <Link
-                      href={`/vocabularies/${v.id}`}
-                      className="mt-4 block outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
-                    >
-                      <div className="flex flex-wrap gap-2">
-                        <span className="inline-flex items-center rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-white ring-1 ring-white/25">
-                          {v.entry_type_label_ja}
-                          <span className="ml-1 text-[11px] font-semibold text-white/80">
-                            {entryTypeKo(v.entry_type)}
-                          </span>
-                        </span>
-                        <span className="inline-flex items-center rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-white ring-1 ring-white/25">
-                          {v.pos_label_ja}
-                          <span className="ml-1 text-[11px] font-semibold text-white/80">
-                            {posKo(v.pos)}
-                          </span>
-                        </span>
-                      </div>
-                    </Link>
-                  </Card>
-                ))}
-          </div>
+          {loading ? (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {Array.from({ length: 9 }).map((_, i) => (
+                <Card key={i} className="border-white/10 bg-white/10 p-5 text-white backdrop-blur">
+                  <Skeleton className="h-6 w-2/3" />
+                  <Skeleton className="mt-3 h-4 w-5/6" />
+                  <div className="mt-4 flex gap-2">
+                    <Skeleton className="h-7 w-16 rounded-full" />
+                    <Skeleton className="h-7 w-20 rounded-full" />
+                  </div>
+                </Card>
+              ))}
+            </div>
+          ) : items && items.length > 0 ? (
+            <VocabularyListVirtualGrid items={items} />
+          ) : null}
 
           {!loading && items && items.length === 0 ? (
             <Card className="border-white/10 bg-white/10 text-center text-white backdrop-blur">

--- a/frontend/src/components/vocabulary/VocabularyListVirtualGrid.tsx
+++ b/frontend/src/components/vocabulary/VocabularyListVirtualGrid.tsx
@@ -1,0 +1,174 @@
+"use client";
+
+import { useWindowVirtualizer, measureElement } from "@tanstack/react-virtual";
+import Link from "next/link";
+import { useSyncExternalStore } from "react";
+
+import { Card } from "@/components/ui/Card";
+import { VocabularyAudioPlayButton } from "@/components/vocabulary/VocabularyAudioPlayButton";
+import type { UserVocabulary } from "@/lib/api/vocabularies";
+
+function subscribeWindowResize(onStoreChange: () => void): () => void {
+  window.addEventListener("resize", onStoreChange);
+  return () => window.removeEventListener("resize", onStoreChange);
+}
+
+function getColumnCountFromWidth(): number {
+  const w = window.innerWidth;
+  if (w < 640) return 1;
+  if (w < 1024) return 2;
+  return 3;
+}
+
+/** Tailwind の sm / lg ブレークポイントに合わせた列数（SSR は 1 列） */
+function useResponsiveColumnCount(): number {
+  return useSyncExternalStore(
+    subscribeWindowResize,
+    getColumnCountFromWidth,
+    () => 1,
+  );
+}
+
+function posKo(pos: string): string {
+  switch (pos) {
+    case "noun":
+      return "명사";
+    case "verb":
+      return "동사";
+    case "adj":
+      return "형용사";
+    case "adv":
+      return "부사";
+    case "particle":
+      return "조사";
+    case "determiner":
+      return "관형사";
+    case "pronoun":
+      return "대명사";
+    case "interjection":
+      return "감탄사";
+    default:
+      return "기타";
+  }
+}
+
+function entryTypeKo(t: string): string {
+  switch (t) {
+    case "word":
+      return "단어";
+    case "phrase":
+      return "숙어";
+    case "idiom":
+      return "관용구";
+    default:
+      return "";
+  }
+}
+
+function VocabularyGridCard({ vocabulary: v, paletteIndex }: { vocabulary: UserVocabulary; paletteIndex: number }) {
+  const palette = paletteIndex % 3;
+  return (
+    <Card
+      className={[
+        "group p-5 transition-transform hover:-translate-y-0.5 hover:shadow-md",
+        "bg-gradient-to-br",
+        palette === 0 ? "from-violet-700/60 via-fuchsia-600/40 to-orange-500/50" : "",
+        palette === 1 ? "from-sky-500/60 via-emerald-500/40 to-lime-400/40" : "",
+        palette === 2 ? "from-orange-500/70 via-rose-500/40 to-violet-700/50" : "",
+        "border-white/10 text-white backdrop-blur",
+      ].join(" ")}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <Link
+          href={`/vocabularies/${v.id}`}
+          className="min-w-0 flex-1 outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+        >
+          <div className="truncate text-lg font-extrabold text-white group-hover:underline">{v.term}</div>
+          <div className="mt-1 line-clamp-2 text-sm text-white/85">{v.meaning_ja}</div>
+        </Link>
+        <div className="flex shrink-0 flex-col items-end gap-2">
+          <div className="text-right text-xs text-white/80">
+            <div className="font-semibold">{v.level_label_ja}</div>
+            <div className="mt-1">{v.pos_label_ja}</div>
+          </div>
+          <VocabularyAudioPlayButton vocabularyId={v.id} initialAudioUrl={v.audio_url} />
+        </div>
+      </div>
+
+      <Link
+        href={`/vocabularies/${v.id}`}
+        className="mt-4 block outline-none focus-visible:ring-2 focus-visible:ring-white/60 focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+      >
+        <div className="flex flex-wrap gap-2">
+          <span className="inline-flex items-center rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-white ring-1 ring-white/25">
+            {v.entry_type_label_ja}
+            <span className="ml-1 text-[11px] font-semibold text-white/80">{entryTypeKo(v.entry_type)}</span>
+          </span>
+          <span className="inline-flex items-center rounded-full bg-white/10 px-3 py-1 text-xs font-medium text-white ring-1 ring-white/25">
+            {v.pos_label_ja}
+            <span className="ml-1 text-[11px] font-semibold text-white/80">{posKo(v.pos)}</span>
+          </span>
+        </div>
+      </Link>
+    </Card>
+  );
+}
+
+type Props = {
+  items: UserVocabulary[];
+};
+
+/**
+ * ウィンドウスクロール連動の仮想化。行単位でグリッドを描画し、見えている行だけ DOM を保つ。
+ */
+export function VocabularyListVirtualGrid({ items }: Props) {
+  const cols = useResponsiveColumnCount();
+  const rowCount = Math.ceil(items.length / cols);
+
+  const rowVirtualizer = useWindowVirtualizer({
+    count: rowCount,
+    estimateSize: () => 220,
+    gap: 12,
+    overscan: 6,
+    measureElement,
+  });
+
+  return (
+    <div
+      className="w-full"
+      style={{
+        height: `${rowVirtualizer.getTotalSize()}px`,
+        position: "relative",
+      }}
+    >
+      {rowVirtualizer.getVirtualItems().map((virtualRow) => {
+        const start = virtualRow.index * cols;
+        const rowItems = items.slice(start, start + cols);
+
+        return (
+          <div
+            key={virtualRow.key}
+            data-index={virtualRow.index}
+            ref={rowVirtualizer.measureElement}
+            className="left-0 top-0 w-full"
+            style={{
+              position: "absolute",
+              transform: `translateY(${virtualRow.start}px)`,
+            }}
+          >
+            <div
+              className="grid gap-3"
+              style={{
+                gridTemplateColumns: `repeat(${cols}, minmax(0, 1fr))`,
+              }}
+            >
+              {rowItems.map((v, i) => (
+                <VocabularyGridCard key={v.id} vocabulary={v} paletteIndex={start + i} />
+              ))}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/frontend/src/lib/api/vocabularies.ts
+++ b/frontend/src/lib/api/vocabularies.ts
@@ -23,12 +23,13 @@ export type UserVocabularyDetail = UserVocabulary & {
 
 export async function listVocabularies(
   token: string | null,
-  input: { level?: number; entry_type?: string; pos?: string } = {}
+  input: { level?: number; entry_type?: string; pos?: string; compact?: boolean } = {}
 ): Promise<{ vocabularies: UserVocabulary[] }> {
   const qs = new URLSearchParams();
   if (typeof input.level === "number") qs.set("level", String(input.level));
   if (input.entry_type) qs.set("entry_type", input.entry_type);
   if (input.pos) qs.set("pos", input.pos);
+  if (input.compact) qs.set("compact", "1");
   const suffix = qs.toString() ? `?${qs.toString()}` : "";
 
   return apiFetch(`/api/v1/vocabularies${suffix}`, { method: "GET", token });

--- a/postman/korean-topik-app.postman_collection.json
+++ b/postman/korean-topik-app.postman_collection.json
@@ -282,6 +282,29 @@
           }
         },
         {
+          "name": "List Vocabularies (compact=1, no example fields)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/api/v1/vocabularies?compact=1",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "v1", "vocabularies"],
+              "query": [
+                {
+                  "key": "compact",
+                  "value": "1"
+                }
+              ]
+            }
+          }
+        },
+        {
           "name": "List Vocabularies (filters: level/entry_type/pos)",
           "request": {
             "method": "GET",


### PR DESCRIPTION
## 概要

語彙一覧の初回表示が、全件・大きめ JSON・大量 DOM で重くなりやすいため、**転送量と描画負荷**を下げる。ページング UI は設けず、一覧ページ専用の取得モードと仮想スクロールで対応する。

## 変更内容

- **API**: クエリ `compact=1` 時は一覧カードに不要な `example_sentence` / `example_translation_ja` / `example_audio_url` を返さず、DB も必要列のみ `SELECT`（`listCardsByStatus` と ReadModel）。
- **互換**: `compact` 未指定時は従来どおり全フィールド（クイズなど既存利用は変更不要）。
- **フロント**: 語彙一覧は `listVocabularies(..., { compact: true })` と `@tanstack/react-virtual` の `useWindowVirtualizer` による行単位の仮想グリッド（列数は 640px / 1024px で 1→2→3）。
- **Postman**: `List Vocabularies (compact=1, no example fields)` を追加。

## テスト

- [x] `make test` 通過
- [x] `make lint-backend` 通過
- [x] フロント `npm run build` / `tsc` はローカルで確認済み

## チェックリスト

- [x] マイグレーションなし
- [x] `.env` やシークレットを含んでいない
- [x] 関連するテストを追加・更新した

## 関連

なし

## デプロイ・開発メモ

- Docker でフロントを動かす場合、`frontend_node_modules` ボリューム利用時は **`docker compose exec frontend npm install`** で `@tanstack/react-virtual` をコンテナ内に反映すること。
