### PR TITLE
feat: 音声ストレージに GCS を選択可能に

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -57,8 +57,13 @@ MAIL_PASSWORD=null
 MAIL_FROM_ADDRESS="hello@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
 
-# 語彙音声の保存ディスク: ローカルは 'public'（デフォルト）、本番 Railway は 'audio_s3' を設定
-# AUDIO_STORAGE_DISK=audio_s3
+# 語彙音声の保存ディスク: ローカルは 'public'（デフォルト）、本番は 'audio_gcs'（GCS）または 'audio_s3'（S3）
+# AUDIO_STORAGE_DISK=audio_gcs
+
+# GCS 音声バケット（AUDIO_STORAGE_DISK=audio_gcs のときに使用）
+# GOOGLE_APPLICATION_CREDENTIALS は TTS と共用できる（GCS 権限を追加したサービスアカウントが必要）
+# GCS_AUDIO_BUCKET=korean-topik-audio
+# GCS_AUDIO_PATH_PREFIX=
 
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=

--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -28,7 +28,12 @@ use App\Services\Vocabulary\Contracts\VocabularySpeechSynthesizerInterface;
 use App\Services\Vocabulary\GoogleCloudVocabularySpeechSynthesizer;
 use App\Services\Vocabulary\StubMp3VocabularySpeechSynthesizer;
 use App\Services\Vocabulary\UnavailableGoogleSpeechSynthesizer;
+use Google\Cloud\Storage\StorageClient;
+use Illuminate\Filesystem\FilesystemAdapter;
+use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\ServiceProvider;
+use League\Flysystem\Filesystem;
+use League\Flysystem\GoogleCloudStorage\GoogleCloudStorageAdapter;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -93,7 +98,19 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Storage::extend('gcs', function ($app, array $config): FilesystemAdapter {
+            $clientOptions = [];
+            $keyFilePath = $config['key_file_path'] ?? null;
+            if ($keyFilePath !== null && $keyFilePath !== '') {
+                $clientOptions['keyFilePath'] = $this->absoluteCredentialsPath((string) $keyFilePath);
+            }
+
+            $storageClient = new StorageClient($clientOptions);
+            $bucket = $storageClient->bucket((string) ($config['bucket'] ?? ''));
+            $adapter = new GoogleCloudStorageAdapter($bucket, (string) ($config['path_prefix'] ?? ''));
+
+            return new FilesystemAdapter(new Filesystem($adapter, $config), $adapter, $config);
+        });
     }
 
     private function googleTextToSpeechCredentialsAreReadable(): bool

--- a/backend/app/Support/VocabularyAudioUrl.php
+++ b/backend/app/Support/VocabularyAudioUrl.php
@@ -8,7 +8,8 @@ use Illuminate\Support\Facades\Storage;
 
 /**
  * DB に保存された音声パス（audio ディスク相対）を、クライアントが取得できる絶対 URL に変換する。
- * ローカル開発は 'public' ディスク、本番は 'audio_s3' ディスクを使用する（AUDIO_STORAGE_DISK で制御）。
+ * ローカル開発は 'public' ディスク、本番は 'audio_gcs'（GCS）または 'audio_s3'（S3）を使用する
+ * （AUDIO_STORAGE_DISK 環境変数で切り替え）。
  */
 final class VocabularyAudioUrl
 {
@@ -39,7 +40,7 @@ final class VocabularyAudioUrl
      * resolveForHttp と同様だが、ローカルディスクの場合はファイルの存在とサイズ（≥ 900B）も検証する。
      * 存在しない・小さすぎる（旧スタブ相当）ファイルは null を返し、
      * クライアントに ensureAudio を呼ばせて再生成を促す。
-     * S3 等のクラウドディスクでは API コストを避けるため検証をスキップし、DB 値を信頼する。
+     * GCS・S3 等のクラウドディスクでは API コストを避けるため検証をスキップし、DB 値を信頼する。
      * API レスポンスのシリアライズ時（一覧・詳細・ブックマーク等）に使用する。
      */
     public static function resolveIfValidForHttp(?string $stored): ?string

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -12,7 +12,8 @@
         "laravel/pint": "^1.29",
         "laravel/sanctum": "^4.3",
         "laravel/tinker": "^3.0",
-        "league/flysystem-aws-s3-v3": "^3.0"
+        "league/flysystem-aws-s3-v3": "^3.0",
+        "league/flysystem-google-cloud-storage": "^3.0"
     },
     "require-dev": {
         "brianium/paratest": "^7.0",

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
+        "google/cloud-storage": "^1.51",
         "google/cloud-text-to-speech": "^2.0",
         "laravel/framework": "^13.0",
         "laravel/pint": "^1.29",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d6a891d0e010519981ba4016309af7b4",
+    "content-hash": "7d1f3d93b0a15950255fbbfda3f7f165",
     "packages": [
         {
             "name": "aws/aws-crt-php",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0314a79e491736c6615a13dfb298d122",
+    "content-hash": "d6a891d0e010519981ba4016309af7b4",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -855,6 +855,131 @@
                 "source": "https://github.com/googleapis/google-auth-library-php/tree/v1.50.1"
             },
             "time": "2026-03-18T20:03:29+00:00"
+        },
+        {
+            "name": "google/cloud-core",
+            "version": "v1.72.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-cloud-php-core.git",
+                "reference": "62cf5d2243af167c75019743c5aebcf25c3905ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-core/zipball/62cf5d2243af167c75019743c5aebcf25c3905ca",
+                "reference": "62cf5d2243af167c75019743c5aebcf25c3905ca",
+                "shasum": ""
+            },
+            "require": {
+                "google/auth": "^1.34",
+                "google/gax": "^1.38.0",
+                "guzzlehttp/guzzle": "^6.5.8||^7.4.4",
+                "guzzlehttp/promises": "^1.4||^2.0",
+                "guzzlehttp/psr7": "^2.6",
+                "monolog/monolog": "^2.9||^3.0",
+                "php": "^8.1",
+                "psr/http-message": "^1.0||^2.0",
+                "rize/uri-template": "~0.3||~0.4"
+            },
+            "require-dev": {
+                "erusev/parsedown": "^1.6",
+                "google/cloud-common-protos": "~0.5||^1.0",
+                "nikic/php-parser": "^5.6",
+                "opis/closure": "^3.7|^4.0",
+                "phpdocumentor/reflection": "^6.0",
+                "phpdocumentor/reflection-docblock": "^5.3.3||^6.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.0",
+                "squizlabs/php_codesniffer": "2.*"
+            },
+            "suggest": {
+                "opis/closure": "May be used to serialize closures to process jobs in the batch daemon. Please require version ^3.",
+                "symfony/lock": "Required for the Spanner cached based session pool. Please require the following commit: 3.3.x-dev#1ba6ac9"
+            },
+            "bin": [
+                "bin/google-cloud-batch"
+            ],
+            "type": "library",
+            "extra": {
+                "component": {
+                    "id": "cloud-core",
+                    "path": "Core",
+                    "entry": "src/ServiceBuilder.php",
+                    "target": "googleapis/google-cloud-php-core.git"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Google\\Cloud\\Core\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Google Cloud PHP shared dependency, providing functionality useful to all components.",
+            "support": {
+                "source": "https://github.com/googleapis/google-cloud-php-core/tree/v1.72.0"
+            },
+            "time": "2026-04-09T21:01:46+00:00"
+        },
+        {
+            "name": "google/cloud-storage",
+            "version": "v1.51.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/googleapis/google-cloud-php-storage.git",
+                "reference": "9ba3d5e8cbd53bf67fab644b5be310e719533def"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/googleapis/google-cloud-php-storage/zipball/9ba3d5e8cbd53bf67fab644b5be310e719533def",
+                "reference": "9ba3d5e8cbd53bf67fab644b5be310e719533def",
+                "shasum": ""
+            },
+            "require": {
+                "google/cloud-core": "^1.72.0",
+                "php": "^8.1",
+                "ramsey/uuid": "^4.2.3"
+            },
+            "require-dev": {
+                "erusev/parsedown": "^1.6",
+                "google/cloud-pubsub": "^2.0",
+                "nikic/php-parser": "^5",
+                "phpdocumentor/reflection": "^6.0",
+                "phpdocumentor/reflection-docblock": "^5.3.3",
+                "phpseclib/phpseclib": "^2.0||^3.0",
+                "phpspec/prophecy-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.0",
+                "squizlabs/php_codesniffer": "2.*"
+            },
+            "suggest": {
+                "google/cloud-pubsub": "May be used to register a topic to receive bucket notifications.",
+                "phpseclib/phpseclib": "May be used in place of OpenSSL for creating signed Cloud Storage URLs. Please require version ^2."
+            },
+            "type": "library",
+            "extra": {
+                "component": {
+                    "id": "cloud-storage",
+                    "path": "Storage",
+                    "entry": "src/StorageClient.php",
+                    "target": "googleapis/google-cloud-php-storage.git"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Google\\Cloud\\Storage\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "description": "Cloud Storage Client for PHP",
+            "support": {
+                "source": "https://github.com/googleapis/google-cloud-php-storage/tree/v1.51.0"
+            },
+            "time": "2026-04-09T21:01:46+00:00"
         },
         {
             "name": "google/cloud-text-to-speech",
@@ -2544,6 +2669,54 @@
             "time": "2026-02-25T16:46:44+00:00"
         },
         {
+            "name": "league/flysystem-google-cloud-storage",
+            "version": "3.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-google-cloud-storage.git",
+                "reference": "0e877148edb3809954559b2987da57e21f7f15a6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-google-cloud-storage/zipball/0e877148edb3809954559b2987da57e21f7f15a6",
+                "reference": "0e877148edb3809954559b2987da57e21f7f15a6",
+                "shasum": ""
+            },
+            "require": {
+                "google/cloud-storage": "^1.23",
+                "league/flysystem": "^3.10.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\GoogleCloudStorage\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
+                }
+            ],
+            "description": "Google Cloud Storage adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "filesystem",
+                "gcs",
+                "google cloud storage"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-google-cloud-storage/tree/3.31.0"
+            },
+            "time": "2026-01-23T15:30:45+00:00"
+        },
+        {
             "name": "league/flysystem-local",
             "version": "3.31.0",
             "source": {
@@ -4219,6 +4392,70 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.2"
             },
             "time": "2025-12-14T04:43:48+00:00"
+        },
+        {
+            "name": "rize/uri-template",
+            "version": "0.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rize/UriTemplate.git",
+                "reference": "abb53c8b73a5b6c24e11f49036ab842f560cad33"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rize/UriTemplate/zipball/abb53c8b73a5b6c24e11f49036ab842f560cad33",
+                "reference": "abb53c8b73a5b6c24e11f49036ab842f560cad33",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.63",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "~10.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Rize\\": "src/Rize"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marut K",
+                    "homepage": "http://twitter.com/rezigned"
+                }
+            ],
+            "description": "PHP URI Template (RFC 6570) supports both expansion & extraction",
+            "keywords": [
+                "RFC 6570",
+                "template",
+                "uri"
+            ],
+            "support": {
+                "issues": "https://github.com/rize/UriTemplate/issues",
+                "source": "https://github.com/rize/UriTemplate/tree/0.4.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.me/rezigned",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/rezigned",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/rize-uri-template",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-12-02T15:19:04+00:00"
         },
         {
             "name": "symfony/clock",

--- a/backend/config/filesystems.php
+++ b/backend/config/filesystems.php
@@ -72,6 +72,17 @@ return [
             'report' => false,
         ],
 
+        // 語彙音声 MP3 の本番用 GCS ディスク（AUDIO_STORAGE_DISK=audio_gcs で有効化）
+        'audio_gcs' => [
+            'driver' => 'gcs',
+            'key_file_path' => env('GOOGLE_APPLICATION_CREDENTIALS'),
+            'bucket' => env('GCS_AUDIO_BUCKET'),
+            'path_prefix' => env('GCS_AUDIO_PATH_PREFIX', ''),
+            'visibility' => 'public',
+            'throw' => false,
+            'report' => false,
+        ],
+
         // 語彙音声 MP3 の本番用 S3 ディスク（AUDIO_STORAGE_DISK=audio_s3 で有効化）
         'audio_s3' => [
             'driver' => 's3',

--- a/docs/deploy/railway-backend.md
+++ b/docs/deploy/railway-backend.md
@@ -149,10 +149,64 @@ Railway の UI で以下の手順を実施する。
 - 再デプロイ後も同じ音声が再生されることを確認
 - Railway の Volumes タブで使用容量が増えていることを確認
 
-#### 7-4. （上級）AWS S3 による永続化
+#### 7-4. GCS（Google Cloud Storage）による永続化
 
-スケールアウト（複数インスタンス）や Railway 外部へのデプロイ先変更に備えるなら AWS S3 が適切。
-以下の環境変数を設定するとコードを変えずに S3 へ切り替わる（`AUDIO_STORAGE_DISK` はリポジトリ対応済み）:
+TTS で既に GCP を使っているなら、同じプロジェクト・サービスアカウントで GCS バケットも利用できる。
+
+##### GCS バケットの作成
+
+1. [GCP コンソール](https://console.cloud.google.com/) → Cloud Storage → バケットを作成
+   - 名前例: `korean-topik-audio`
+   - リージョン: `asia-northeast1`（東京）
+   - アクセス制御: **「均一」（uniform）** を選択
+2. **バケットの公開設定**（ブラウザから音声 URL を直接再生するため）
+   - バケット → 「権限」タブ → 「プリンシパルを追加」
+   - 新しいプリンシパル: `allUsers`
+   - ロール: `Storage オブジェクト閲覧者`（roles/storage.objectViewer）
+   - 保存
+3. **CORS 設定**（Vercel フロントからのリクエストを許可）
+
+```bash
+# cors.json を作成
+cat > /tmp/cors.json <<'EOF'
+[
+  {
+    "origin": ["https://*.vercel.app", "https://korean-topik-app.vercel.app"],
+    "method": ["GET"],
+    "maxAgeSeconds": 3600
+  }
+]
+EOF
+
+# gcloud CLI で適用
+gcloud storage buckets update gs://korean-topik-audio --cors-file=/tmp/cors.json
+```
+
+##### サービスアカウントに GCS 権限を追加
+
+TTS 用サービスアカウントに以下のロールを追加（GCP コンソール → IAM → サービスアカウントを選択 → 「権限を編集」）:
+
+- `Storage オブジェクト管理者`（roles/storage.objectAdmin）
+
+##### Railway 環境変数に追加
+
+| 変数名 | 値 |
+|--------|-----|
+| `AUDIO_STORAGE_DISK` | `audio_gcs` |
+| `GCS_AUDIO_BUCKET` | バケット名（例: `korean-topik-audio`） |
+| `GCS_AUDIO_PATH_PREFIX` | （任意）フォルダプレフィックス、通常は空欄 |
+
+`GOOGLE_APPLICATION_CREDENTIALS` は TTS 用に設定済みのものをそのまま使用。
+
+##### 動作確認
+
+- 再生ボタンを押して音声が流れることを確認
+- GCS バケットに `vocabulary-audio/*.mp3` が作成されていることを確認
+- 再デプロイ後も同じ音声が再生されることを確認
+
+#### 7-5. （上級）AWS S3 による永続化
+
+AWS アカウントがある場合。S3 バケットは「ACL 有効」「パブリックアクセス一部許可（ACL のみ）」が必要。
 
 | 変数名 | 値 |
 |--------|-----|
@@ -161,8 +215,6 @@ Railway の UI で以下の手順を実施する。
 | `AWS_SECRET_ACCESS_KEY` | シークレットキー |
 | `AWS_DEFAULT_REGION` | `ap-northeast-1` |
 | `AWS_BUCKET` | バケット名 |
-
-S3 バケットは「ACL 有効」「パブリックアクセス一部許可（ACL のみ）」が必要。
 
 ### 8. トラブルシュート
 


### PR DESCRIPTION
## 概要

本番環境で音声ファイルを安定して永続化できるように、音声の保存先として Google Cloud Storage（GCS）を選択できるようにしました（従来のローカル/Volume 前提から切り替え可能）。

## 変更内容

- `AUDIO_STORAGE_DISK=audio_gcs` で音声保存先を GCS に切り替え可能に
- `Storage::disk('audio_gcs')` を解決できるよう、アプリ起動時に GCS ドライバを登録
- filesystem 設定とデプロイ手順（Railway）を更新

## テスト

- [x] `make test` 通過
- [x] `make lint-backend` 通過
- [ ] 手動動作確認済み（確認内容: ）

## チェックリスト

- [ ] マイグレーションあり → `make migrate` を実行済み or 手順を本文に記載（※マイグレーションなし）
- [x] `.env` やシークレットを含んでいない
- [ ] 関連するテストを追加・更新した

## 関連

なし

Made with [Cursor](https://cursor.com)