### PR TITLE
fix: GCS音声のURL/保存で発生する500/503を解消

### DIFF
--- a/backend/app/Support/VocabularyAudioUrl.php
+++ b/backend/app/Support/VocabularyAudioUrl.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Support;
 
+use Illuminate\Filesystem\FilesystemAdapter;
 use Illuminate\Support\Facades\Storage;
+use Throwable;
 
 /**
  * DB に保存された音声パス（audio ディスク相対）を、クライアントが取得できる絶対 URL に変換する。
@@ -18,6 +20,27 @@ final class VocabularyAudioUrl
         return (string) config('filesystems.audio_disk', 'public');
     }
 
+    private static function gcsPublicUrl(string $stored): ?string
+    {
+        $bucket = trim((string) config('filesystems.disks.audio_gcs.bucket', ''));
+        if ($bucket === '') {
+            return null;
+        }
+
+        $prefix = (string) (config('filesystems.disks.audio_gcs.path_prefix') ?? '');
+        $prefix = trim($prefix, '/');
+
+        $path = ltrim($stored, '/');
+        $fullPath = ($prefix !== '') ? ($prefix.'/'.$path) : $path;
+
+        // Google Cloud Storage public URL format:
+        // https://storage.googleapis.com/<bucket>/<object>
+        // Keep "/" separators but encode path segments.
+        $encoded = implode('/', array_map('rawurlencode', explode('/', $fullPath)));
+
+        return 'https://storage.googleapis.com/'.rawurlencode($bucket).'/'.$encoded;
+    }
+
     public static function resolveForHttp(?string $stored): ?string
     {
         if ($stored === null || $stored === '') {
@@ -28,7 +51,22 @@ final class VocabularyAudioUrl
             return $stored;
         }
 
-        $url = Storage::disk(self::audioDiskName())->url($stored);
+        $diskName = self::audioDiskName();
+        $driver = (string) (config("filesystems.disks.{$diskName}.driver") ?? 'local');
+
+        try {
+            /** @var FilesystemAdapter $disk */
+            $disk = Storage::disk($diskName);
+            $url = $disk->url($stored);
+        } catch (Throwable) {
+            // Some custom disks (e.g. GCS via Flysystem adapter) may not support url().
+            $url = '';
+        }
+
+        if ($url === '' && $driver === 'gcs') {
+            return self::gcsPublicUrl($stored);
+        }
+
         if (str_starts_with($url, 'http://') || str_starts_with($url, 'https://')) {
             return $url;
         }

--- a/backend/tests/Unit/Support/VocabularyAudioUrlTest.php
+++ b/backend/tests/Unit/Support/VocabularyAudioUrlTest.php
@@ -33,4 +33,22 @@ class VocabularyAudioUrlTest extends TestCase
         $this->assertStringStartsWith('http://api.test/storage/', $resolved);
         $this->assertStringContainsString('vocabulary-audio/01HZTEST.mp3', $resolved);
     }
+
+    public function test_resolves_gcs_public_url_when_url_method_is_unavailable(): void
+    {
+        // Simulate production config where AUDIO_STORAGE_DISK=audio_gcs
+        config([
+            'filesystems.audio_disk' => 'audio_gcs',
+            'filesystems.disks.audio_gcs.driver' => 'gcs',
+            'filesystems.disks.audio_gcs.bucket' => 'korean-topik-app-prod-audio-file',
+            'filesystems.disks.audio_gcs.path_prefix' => '',
+        ]);
+
+        $resolved = VocabularyAudioUrl::resolveForHttp('vocabulary-audio/01HZTEST.mp3');
+
+        $this->assertSame(
+            'https://storage.googleapis.com/korean-topik-app-prod-audio-file/vocabulary-audio/01HZTEST.mp3',
+            $resolved
+        );
+    }
 }


### PR DESCRIPTION
## 概要

本番で `AUDIO_STORAGE_DISK=audio_gcs` の場合、GCS ディスクの URL 解決・初期化処理・保存時オプション/visibility が原因で例外や GCS 書き込み失敗が発生し、
- 語彙一覧 API（`GET /api/v1/vocabularies?compact=1`）が **500**
- 音声生成 API（`POST /api/v1/vocabularies/{id}/audio` 等）が **503**
- GCS 側で `WriteObject INVALID_ARGUMENT` が出てオブジェクトが作られない
ことがありました。

GCS 用の公開 URL へフォールバックし、`Storage::extend('gcs', ...)` のクロージャ束縛問題を解消し、
さらに UBLA 前提で ACL/visibility 指定を抑止して保存失敗を防ぎます。

## 変更内容

- GCS ディスクで `Storage::disk(...)->url()` が失敗した場合に、`https://storage.googleapis.com/<bucket>/<object>` 形式の URL を返すフォールバックを追加
- `Storage::extend('gcs', ...)` のクロージャ内で `$this` を参照すると束縛が変わり致命的エラーになるケースを解消（static + use に変更）
- 音声保存時、local 以外のディスクでは `put(..., "public")` を渡さない（UBLA 等で `WriteObject INVALID_ARGUMENT` になるのを回避）
- GCS ディスク設定の `visibility` を `private` に変更（UBLA 有効バケットで object ACL を要求しない）
- 上記の挙動を担保するユニットテストを追加

## テスト

- [x] `make test` 通過
- [x] `make lint-backend` 通過
- [ ] 手動動作確認済み（確認内容: 本番で語彙一覧が500にならない／音声生成が失敗しない／GCSにオブジェクトが作成される）

## チェックリスト

- [ ] マイグレーションあり → `make migrate` を実行済み or 手順を本文に記載（※マイグレーションなし）
- [x] `.env` やシークレットを含んでいない
- [x] 関連するテストを追加・更新した

## 関連

なし