### PR TITLE
fix: GCSディスク初期化時の $this 束縛バグを解消

### DIFF
--- a/backend/app/Providers/AppServiceProvider.php
+++ b/backend/app/Providers/AppServiceProvider.php
@@ -104,16 +104,23 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        Storage::extend('gcs', function ($app, array $config): FilesystemAdapter {
+        // NOTE:
+        // Storage::extend のクロージャ内で $this を参照すると、実行時の束縛が変わる環境があり
+        // FilesystemAdapter 経由で Flysystem に委譲されて致命的エラーになることがあるため、
+        // 必要な処理は use で捕まえ、クロージャ自体は static にする。
+        $decodedGoogleCredentialsB64 = fn (): ?array => $this->decodedGoogleCredentialsB64();
+        $absoluteCredentialsPath = fn (string $raw): string => $this->absoluteCredentialsPath($raw);
+
+        Storage::extend('gcs', static function ($app, array $config) use ($decodedGoogleCredentialsB64, $absoluteCredentialsPath): FilesystemAdapter {
             $clientOptions = [];
 
             // GOOGLE_CREDENTIALS_B64: base64 エンコードした JSON（Railway 等エフェメラル環境向け、TTS と共用）
-            $credentialsArray = $this->decodedGoogleCredentialsB64();
+            $credentialsArray = $decodedGoogleCredentialsB64();
             if ($credentialsArray !== null) {
                 $clientOptions['keyFile'] = $credentialsArray;
             } elseif (($keyFilePath = $config['key_file_path'] ?? null) !== null && $keyFilePath !== '') {
                 // GOOGLE_APPLICATION_CREDENTIALS: ファイルパス方式（Docker 等の永続ファイルシステム向け）
-                $clientOptions['keyFilePath'] = $this->absoluteCredentialsPath((string) $keyFilePath);
+                $clientOptions['keyFilePath'] = $absoluteCredentialsPath((string) $keyFilePath);
             }
 
             $storageClient = new StorageClient($clientOptions);


### PR DESCRIPTION
Storage::extend のクロージャ内で $this を参照すると FilesystemAdapter に束縛されるケースがあり、 decodedGoogleCredentialsB64() 呼び出しが Flysystem 側に委譲されて致命的エラーになっていた。 static クロージャ + use で参照を固定し、音声生成APIの失敗を解消する。

Made-with: Cursor

## 概要

<!-- なぜこの PR が必要か。背景・目的を 1〜3 文で。 -->

## 変更内容

<!-- 何をどう変えたか。箇条書き。ファイル名の羅列だけにしない。 -->

-

## テスト

- [ ] `make test` 通過
- [ ] `make lint-backend` 通過
- [ ] 手動動作確認済み（確認内容: ）

## チェックリスト

- [ ] マイグレーションあり → `make migrate` を実行済み or 手順を本文に記載
- [ ] `.env` やシークレットを含んでいない
- [ ] 関連するテストを追加・更新した

## 関連

<!-- Issue や議論へのリンク。なければ「なし」。 -->
<!-- Closes #123 -->
