### PR TITLE
fix: GCS/非localで音声保存時にACL指定しない

### DIFF
--- a/backend/app/Services/Vocabulary/EnsureVocabularyAudioService.php
+++ b/backend/app/Services/Vocabulary/EnsureVocabularyAudioService.php
@@ -23,6 +23,24 @@ final class EnsureVocabularyAudioService
         private readonly VocabularySpeechSynthesizerInterface $synthesizer,
     ) {}
 
+    private function putAudioBinary(string $relativePath, string $binary): void
+    {
+        $diskName = (string) config('filesystems.audio_disk', 'public');
+        $driver = (string) (config("filesystems.disks.{$diskName}.driver") ?? 'local');
+
+        $disk = Storage::disk($diskName);
+
+        // GCS (UBLA) / S3 では object ACL を付与すると INVALID_ARGUMENT 等で弾かれることがあるため、
+        // local ディスク以外では明示的な visibility を渡さない。
+        if ($driver === 'local') {
+            $disk->put($relativePath, $binary, 'public');
+
+            return;
+        }
+
+        $disk->put($relativePath, $binary);
+    }
+
     /**
      * @param  bool  $onlyPublished  true のとき status=published の行のみ対象
      *
@@ -82,7 +100,7 @@ final class EnsureVocabularyAudioService
             }
 
             $relativePath = 'vocabulary-audio/'.$model->id.'.mp3';
-            Storage::disk((string) config('filesystems.audio_disk', 'public'))->put($relativePath, $binary, 'public');
+            $this->putAudioBinary($relativePath, $binary);
             $model->audio_url = $relativePath;
             $model->save();
 
@@ -154,7 +172,7 @@ final class EnsureVocabularyAudioService
             }
 
             $relativePath = 'vocabulary-audio/'.$model->id.'-example.mp3';
-            Storage::disk((string) config('filesystems.audio_disk', 'public'))->put($relativePath, $binary, 'public');
+            $this->putAudioBinary($relativePath, $binary);
             $model->example_audio_url = $relativePath;
             $model->save();
 


### PR DESCRIPTION
GCS（特に Uniform bucket-level access 有効時）では object ACL を付与すると WriteObject INVALID_ARGUMENT になることがある。
local 以外のディスクでは put の visibility を省略して保存失敗を防ぐ。

Made-with: Cursor

## 概要

<!-- なぜこの PR が必要か。背景・目的を 1〜3 文で。 -->

## 変更内容

<!-- 何をどう変えたか。箇条書き。ファイル名の羅列だけにしない。 -->

-

## テスト

- [ ] `make test` 通過
- [ ] `make lint-backend` 通過
- [ ] 手動動作確認済み（確認内容: ）

## チェックリスト

- [ ] マイグレーションあり → `make migrate` を実行済み or 手順を本文に記載
- [ ] `.env` やシークレットを含んでいない
- [ ] 関連するテストを追加・更新した

## 関連

<!-- Issue や議論へのリンク。なければ「なし」。 -->
<!-- Closes #123 -->
