### PR TITLE
fix: GCSディスクのvisibilityをprivateに変更

### DIFF
--- a/backend/config/filesystems.php
+++ b/backend/config/filesystems.php
@@ -81,7 +81,10 @@ return [
             'key_file_path' => env('GOOGLE_APPLICATION_CREDENTIALS'),
             'bucket' => env('GCS_AUDIO_BUCKET'),
             'path_prefix' => env('GCS_AUDIO_PATH_PREFIX', ''),
-            'visibility' => 'public',
+            // UBLA（Uniform bucket-level access）有効なバケットでは object ACL が禁止されるため、
+            // visibility=public を指定すると WriteObject INVALID_ARGUMENT になることがある。
+            // 公開アクセスはバケットの IAM（allUsers に objectViewer 付与など）で制御する。
+            'visibility' => 'private',
             'throw' => false,
             'report' => false,
         ],


### PR DESCRIPTION
UBLA（Uniform bucket-level access）有効バケットでは object ACL が禁止されるため、 visibility=public が原因で WriteObject INVALID_ARGUMENT になることがある。 公開はバケットIAMで制御する前提で private にする。

Made-with: Cursor

## 概要

<!-- なぜこの PR が必要か。背景・目的を 1〜3 文で。 -->

## 変更内容

<!-- 何をどう変えたか。箇条書き。ファイル名の羅列だけにしない。 -->

-

## テスト

- [ ] `make test` 通過
- [ ] `make lint-backend` 通過
- [ ] 手動動作確認済み（確認内容: ）

## チェックリスト

- [ ] マイグレーションあり → `make migrate` を実行済み or 手順を本文に記載
- [ ] `.env` やシークレットを含んでいない
- [ ] 関連するテストを追加・更新した

## 関連

<!-- Issue や議論へのリンク。なければ「なし」。 -->
<!-- Closes #123 -->
