### PR TITLE
fix: Vercel Preview からの CORS を許可

### DIFF
--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -24,7 +24,10 @@ return [
         array_filter(array_map('trim', explode(',', (string) env('CORS_ALLOWED_ORIGINS', ''))))
     ))),
 
-    'allowed_origins_patterns' => [],
+    'allowed_origins_patterns' => [
+        // Vercel Preview URL (例: https://<project>-git-<branch>-<hash>-<team>.vercel.app)
+        '^https://.*\\.vercel\\.app$',
+    ],
 
     'allowed_headers' => ['*'],
 


### PR DESCRIPTION
## 概要
Vercel の Preview URL からバックエンド API を呼ぶと CORS でブロックされるため、Preview ドメイン（`*.vercel.app`）を許可してプレビュー環境でも疎通できるようにします。

## 変更内容
- `allowed_origins_patterns` に `*.vercel.app` を許可する正規表現を追加

## テスト
- [x] `make test` 通過
- [x] `make lint-backend` 通過
- [ ] 手動動作確認済み（確認内容: ）

## チェックリスト
- [ ] マイグレーションあり → `make migrate` を実行済み or 手順を本文に記載
- [x] `.env` やシークレットを含んでいない
- [ ] 関連するテストを追加・更新した

## 関連
なし

Made with [Cursor](https://cursor.com)