### PR TITLE
fix: プレビュー環境の YAML エラー修正 + Seed データ投入

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -100,15 +100,17 @@ jobs:
             const marker = '<!-- preview-env -->';
             const now = new Date().toISOString().replace('T', ' ').slice(0, 19);
 
-            const body = `${marker}
-## プレビュー環境 🚀
-
-| | URL |
-|---|---|
-| **フロントエンド** | [${frontendUrl}](${frontendUrl}) |
-| **バックエンド API** | [${backendUrl}](${backendUrl}) |
-
-> 最終更新: ${now} UTC`;
+            const body = [
+              marker,
+              '## プレビュー環境 🚀',
+              '',
+              '| | URL |',
+              '|---|---|',
+              `| **フロントエンド** | [${frontendUrl}](${frontendUrl}) |`,
+              `| **バックエンド API** | [${backendUrl}](${backendUrl}) |`,
+              '',
+              `> 最終更新: ${now} UTC`,
+            ].join('\n');
 
             const { data: comments } = await github.rest.issues.listComments({
               owner:        context.repo.owner,

--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -12,11 +12,10 @@ jobs:
   deploy-frontend:
     runs-on: ubuntu-latest
     # Railway PR 環境の成功通知のみ処理する。
-    # Railway は PR 環境を "pr-{number}" という environment 名で GitHub に登録する。
-    # 実際の値は Actions ログの github.event.deployment.environment で要確認。
+    # Railway の environment 名は "{project}-pr-{number}" 形式（例: korean-topik-app-pr-104）。
     if: |
       github.event.deployment_status.state == 'success' &&
-      startsWith(github.event.deployment.environment, 'pr-') &&
+      contains(github.event.deployment.environment, '-pr-') &&
       github.event.deployment_status.environment_url != ''
 
     steps:

--- a/backend/Procfile
+++ b/backend/Procfile
@@ -1,1 +1,1 @@
-web: php artisan migrate --force && php artisan storage:link --force && php -S 0.0.0.0:$PORT -t public
+web: php artisan migrate --force && php artisan storage:link --force && ([ "$APP_ENV" = "preview" ] && php artisan db:seed --force || true) && php -S 0.0.0.0:$PORT -t public


### PR DESCRIPTION
## 概要

2つの問題を修正。

## 変更内容

### 1. YAMLエラー修正（`preview-deploy.yml` L106）

template literal の中にインデントなし行（`## ...`、`| |`）があり、YAML の block scalar パーサーがエラーになっていた。配列 join 方式に書き換えて解決。

```js
// Before: YAML が壊れる
const body = `${marker}
## プレビュー環境 🚀
| | URL |  ...`;

// After: 正常
const body = [marker, '## プレビュー環境 🚀', ...].join('\n');
```

### 2. プレビュー環境へのSeedデータ投入（`backend/Procfile`）

`APP_ENV=preview` のときだけ `db:seed --force` を実行するよう条件分岐を追加。全 Seeder は `updateOrCreate` / `firstOrCreate` で冪等なので再起動時の重複なし。

```diff
- web: php artisan migrate --force && php artisan storage:link --force && php -S ...
+ web: php artisan migrate --force && php artisan storage:link --force && ([ "$APP_ENV" = "preview" ] && php artisan db:seed --force || true) && php -S ...
```

## テスト
- [ ] `make test` 通過
- [ ] `make lint-backend` 通過
- [ ] GitHub Actions の YAML 構文エラーが解消されることを確認

## チェックリスト
- [x] production の Procfile は変更なし（`APP_ENV != "preview"` の場合は seed をスキップ）
- [x] マイグレーションなし