### PR TITLE
fix: CORS パターンに preg_match 用デリミタを追加

### DIFF
--- a/backend/config/cors.php
+++ b/backend/config/cors.php
@@ -26,7 +26,8 @@ return [
 
     'allowed_origins_patterns' => [
         // Vercel Preview URL (例: https://<project>-git-<branch>-<hash>-<team>.vercel.app)
-        '^https://.*\\.vercel\\.app$',
+        // preg_match はデリミタが必要なため # で囲む
+        '#^https://.*\\.vercel\\.app$#',
     ],
 
     'allowed_headers' => ['*'],


### PR DESCRIPTION
## 概要

`config/cors.php` の `allowed_origins_patterns` に設定していた正規表現にデリミタが抜けており、Vercel プレビュー URL からの全リクエストが CORS エラーになっていた。

## 原因

PHP の `preg_match()` はパターンにデリミタ（`/`, `#`, `{` 等）が必須。  
`fruitcake/php-cors` はパターンをそのまま `preg_match($pattern, $origin)` に渡すため、デリミタなしでは正規表現が無効になりマッチしない。

```php
// Before（デリミタなし → 無効）
'^https://.*\\.vercel\\.app$'

// After（# デリミタ → 正常動作）
'#^https://.*\\.vercel\\.app$#'
```

## 影響

- Vercel プレビュー URL（`*.vercel.app`）から本番バックエンドへの API リクエストが通るようになる
- フロントのみのPRでも Vercel プレビュー + 本番バックエンドで動作確認可能になる

## テスト
- [ ] `make test` 通過
- [ ] `make lint-backend` 通過
- [ ] Vercel プレビュー URL から API が叩けることを確認