### PR TITLE
feat: ダーク glassmorphism デザインシステムを全ページに適用

### DIFF
--- a/frontend/src/app/bookmarks/page.tsx
+++ b/frontend/src/app/bookmarks/page.tsx
@@ -62,42 +62,42 @@ export default function BookmarksPage() {
 
   if (state.status === "loading") {
     return (
-      <div className="flex flex-1 items-center justify-center bg-gradient-to-b from-sky-600 via-teal-500 to-cyan-700 px-4 py-10 text-white">
-        <div className="text-sm text-white/80">読み込み中...</div>
+      <div className="flex flex-1 items-center justify-center bg-[#08091A] px-4 py-10 text-[#F0F0FF]">
+        <div className="text-sm text-[#9499C4]">読み込み中...</div>
       </div>
     );
   }
 
   if (state.status === "guest") {
     return (
-      <div className="flex flex-1 items-center justify-center bg-gradient-to-b from-sky-600 via-teal-500 to-cyan-700 px-4 py-10 text-white">
-        <Card className="w-full max-w-md space-y-4 border-white/10 bg-white/10 text-white backdrop-blur">
+      <div className="flex flex-1 items-center justify-center bg-[#08091A] px-4 py-10 text-[#F0F0FF]">
+        <Card className="w-full max-w-md space-y-4 border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
           <div>
-            <h1 className="text-2xl font-extrabold tracking-tight text-white drop-shadow-sm">
+            <h1 className="text-2xl font-extrabold tracking-tight text-[#F0F0FF]">
               ブックマークは会員の方のみ
-              <span className="mt-1 block text-base font-semibold text-white/85">
+              <span className="mt-1 block text-base font-semibold text-[#9499C4]">
                 북마크는 회원 전용이에요
               </span>
             </h1>
-            <p className="mt-3 text-sm leading-relaxed text-white/85">
+            <p className="mt-3 text-sm leading-relaxed text-[#BCC0E8]">
               ブックマークに語彙を保存したり、一覧で復習したりするには
-              <strong className="text-white">無料の会員登録（アカウント作成）</strong>
+              <strong className="text-[#F0F0FF]">無料の会員登録（アカウント作成）</strong>
               が必要です。登録後はいつでもログインしてご利用いただけます。
             </p>
-            <p className="mt-2 text-sm leading-relaxed text-white/80">
+            <p className="mt-2 text-sm leading-relaxed text-[#9499C4]">
               まずはアカウントを作成して、自分だけの単語リストを作ってみましょう。
             </p>
           </div>
           <div className="flex flex-col gap-2 sm:flex-row sm:justify-center">
             <Link
               href="/register"
-              className="inline-flex items-center justify-center rounded-lg bg-white px-4 py-2.5 text-center text-sm font-semibold text-zinc-900 hover:bg-white/90"
+              className="inline-flex items-center justify-center rounded-xl bg-[linear-gradient(135deg,#6366f1,#3b82f6)] px-4 py-2.5 text-center text-sm font-semibold text-white shadow-[0_4px_16px_rgba(99,102,241,0.3)] hover:opacity-90"
             >
               無料で会員登録
             </Link>
             <Link
               href="/login"
-              className="inline-flex items-center justify-center rounded-lg border border-white/40 bg-white/10 px-4 py-2.5 text-center text-sm font-semibold text-white hover:bg-white/15"
+              className="inline-flex items-center justify-center rounded-xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-2.5 text-center text-sm font-semibold text-[#BCC0E8] hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF]"
             >
               ログイン
             </Link>
@@ -108,31 +108,36 @@ export default function BookmarksPage() {
   }
 
   return (
-    <div className="min-h-[calc(100vh-56px)] bg-gradient-to-b from-sky-600 via-teal-500 to-cyan-700 px-4 py-8 text-white">
-      <div className="mx-auto w-full max-w-5xl space-y-6">
+    <div className="relative min-h-[calc(100vh-56px)] overflow-hidden bg-[#08091A] px-4 py-8 text-[#F0F0FF]">
+      <div
+        aria-hidden
+        className="absolute rounded-full pointer-events-none blur-[80px] bg-[rgba(99,102,241,0.10)]"
+        style={{ width: 500, height: 350, top: -80, left: "50%", transform: "translateX(-50%)" }}
+      />
+      <div className="relative mx-auto w-full max-w-5xl space-y-6">
         <div className="flex flex-col gap-2">
-          <h1 className="text-3xl font-extrabold tracking-tight text-white drop-shadow-sm sm:text-4xl">
-            ブックマーク
-            <span className="ml-2 align-baseline text-lg font-semibold text-white/85">
+          <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
+            <span className="bg-[linear-gradient(135deg,#6366f1,#3b82f6)] bg-clip-text text-transparent">ブックマーク</span>
+            <span className="ml-2 align-baseline text-lg font-semibold text-[#9499C4]">
               북마크
             </span>
           </h1>
-          <p className="text-sm text-white/80">保存した語彙を確認できます。</p>
+          <p className="text-sm text-[#BCC0E8]">保存した語彙を確認できます。</p>
         </div>
 
         <Section
           title="保存済み語彙"
           subtitle="저장된 단어"
           description={loading ? "読み込み中..." : `件数: ${items?.length ?? 0}`}
-          right={error ? <div className="text-sm font-medium text-red-200">{error}</div> : null}
-          headerClassName="rounded-2xl bg-white/10 px-4 py-3 ring-1 ring-white/10 backdrop-blur"
-          titleClassName="text-white drop-shadow-sm"
-          descriptionClassName="text-white/80"
+          right={error ? <div className="text-sm font-medium text-[#fb7185]">{error}</div> : null}
+          headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
+          titleClassName="text-[#F0F0FF]"
+          descriptionClassName="text-[#9499C4]"
         >
           {loading ? (
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
               {Array.from({ length: 6 }).map((_, i) => (
-                <Card key={i} className="border-white/10 bg-white/10 p-5 text-white backdrop-blur">
+                <Card key={i} className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] p-5 backdrop-blur-xl">
                   <Skeleton className="h-6 w-2/3" />
                   <Skeleton className="mt-3 h-4 w-5/6" />
                   <div className="mt-4 flex gap-2">
@@ -147,17 +152,17 @@ export default function BookmarksPage() {
           ) : null}
 
           {!loading && items && items.length === 0 ? (
-            <Card className="border-white/10 bg-white/10 text-center text-white backdrop-blur">
-              <div className="text-sm font-semibold text-white">
+            <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-center text-[#F0F0FF] backdrop-blur-xl">
+              <div className="text-sm font-semibold text-[#F0F0FF]">
                 ブックマークがありません
               </div>
-              <div className="mt-1 text-sm text-white/80">
+              <div className="mt-1 text-sm text-[#9499C4]">
                 語彙詳細ページからブックマークに追加できます。
               </div>
               <div className="mt-4">
                 <Link
                   href="/vocabularies"
-                  className="inline-flex items-center gap-1 rounded-full bg-white/10 px-4 py-2 text-sm font-medium text-white ring-1 ring-white/25 hover:bg-white/15"
+                  className="inline-flex items-center gap-1 rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-2 text-sm font-medium text-[#BCC0E8] hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF]"
                 >
                   語彙一覧へ
                 </Link>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1,27 +1,85 @@
 @import "tailwindcss";
 
+/* ── TOPIK Design System — Color & Typography Tokens ── */
 :root {
-  --background: #ffffff;
-  --foreground: #171717;
+  /* App background — deep navy */
+  --background: #08091A;
+  --foreground: #F0F0FF;
+
+  /* Base palette */
+  --color-base-900: #08091A;
+  --color-base-800: #0D0F26;
+  --color-base-700: #131530;
+  --color-base-600: #1A1D3D;
+  --color-base-500: #22264A;
+
+  /* Brand — Indigo × Blue */
+  --color-indigo: #6366f1;
+  --color-indigo-light: #818cf8;
+  --color-blue: #3b82f6;
+  --color-blue-light: #60a5fa;
+  --brand-gradient: linear-gradient(135deg, #6366f1, #3b82f6);
+
+  /* Glass surfaces */
+  --glass-1: rgba(255, 255, 255, 0.03);
+  --glass-2: rgba(255, 255, 255, 0.05);
+  --glass-3: rgba(255, 255, 255, 0.08);
+  --glass-4: rgba(255, 255, 255, 0.12);
+  --glass-5: rgba(255, 255, 255, 0.16);
+  --glass-border: rgba(255, 255, 255, 0.08);
+  --glass-border-strong: rgba(255, 255, 255, 0.15);
+
+  /* Foreground hierarchy */
+  --fg-1: #F0F0FF;
+  --fg-2: #BCC0E8;
+  --fg-3: #9499C4;
+  --fg-4: #5C6199;
+
+  /* Status */
+  --color-success: #10b981;
+  --color-success-light: #34d399;
+  --color-error: #f43f5e;
+  --color-error-light: #fb7185;
+  --color-warning: #f59e0b;
+  --color-warning-light: #fbbf24;
+
+  /* Shadows */
+  --shadow-glow-indigo: 0 0 24px rgba(99, 102, 241, 0.35);
+  --shadow-glow-blue: 0 0 24px rgba(59, 130, 246, 0.35);
+  --shadow-card: 0 8px 32px rgba(0, 0, 0, 0.4);
 }
 
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);
-  --font-sans: var(--font-noto-sans-jp);
-  --font-mono: var(--font-geist-mono);
-}
+  --font-sans: var(--font-noto-sans-kr), var(--font-noto-sans-jp);
+  --font-mono: var(--font-jetbrains-mono), var(--font-geist-mono);
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
+  /* Brand utilities */
+  --color-topik-indigo: #6366f1;
+  --color-topik-indigo-light: #818cf8;
+  --color-topik-blue: #3b82f6;
+  --color-topik-blue-light: #60a5fa;
+  --color-topik-success: #10b981;
+  --color-topik-success-light: #34d399;
+  --color-topik-error: #f43f5e;
+  --color-topik-error-light: #fb7185;
+  --color-topik-warning: #f59e0b;
+
+  /* Foreground utilities */
+  --color-topik-fg1: #F0F0FF;
+  --color-topik-fg2: #BCC0E8;
+  --color-topik-fg3: #9499C4;
+  --color-topik-fg4: #5C6199;
+
+  /* Surface utilities */
+  --color-topik-surface: #0D0F26;
+  --color-topik-elevated: #131530;
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-sans), var(--font-noto-sans-kr), system-ui, -apple-system, "Segoe UI",
-    Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji";
+  font-family: var(--font-sans), system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
 }
+

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,12 +1,13 @@
 import type { Metadata } from "next";
-import { Geist_Mono, Noto_Sans_JP, Noto_Sans_KR } from "next/font/google";
+import { JetBrains_Mono, Noto_Sans_JP, Noto_Sans_KR } from "next/font/google";
 import "./globals.css";
 import { AuthProvider } from "@/components/auth/AuthProvider";
 import { AppHeader } from "@/components/nav/AppHeader";
 
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const jetbrainsMono = JetBrains_Mono({
+  variable: "--font-jetbrains-mono",
   subsets: ["latin"],
+  weight: ["400", "500", "700"],
 });
 
 const notoSansJp = Noto_Sans_JP({
@@ -18,7 +19,7 @@ const notoSansJp = Noto_Sans_JP({
 const notoSansKr = Noto_Sans_KR({
   variable: "--font-noto-sans-kr",
   subsets: ["latin"],
-  weight: ["400", "500", "600", "700"],
+  weight: ["300", "400", "500", "600", "700"],
 });
 
 export const metadata: Metadata = {
@@ -38,7 +39,7 @@ export default function RootLayout({
   return (
     <html
       lang="ja"
-      className={`${notoSansJp.variable} ${notoSansKr.variable} ${geistMono.variable} h-full antialiased`}
+      className={`${notoSansJp.variable} ${notoSansKr.variable} ${jetbrainsMono.variable} h-full antialiased`}
     >
       <body className="min-h-full flex flex-col">
         <AuthProvider>

--- a/frontend/src/app/me/page.tsx
+++ b/frontend/src/app/me/page.tsx
@@ -57,18 +57,18 @@ export default function MePage() {
 
   if (state.status === "guest") {
     return (
-      <div className="min-h-[calc(100vh-56px)] bg-gradient-to-b from-sky-600 via-teal-500 to-cyan-700 px-4 py-8 text-white">
+      <div className="relative min-h-[calc(100vh-56px)] overflow-hidden bg-[#08091A] px-4 py-8 text-[#F0F0FF]">
         <div className="mx-auto w-full max-w-2xl">
-          <Card className="border-white/10 bg-white/10 text-white backdrop-blur">
-            <h1 className="text-2xl font-extrabold tracking-tight text-white drop-shadow-sm">
+          <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
+            <h1 className="text-2xl font-extrabold tracking-tight text-[#F0F0FF]">
               未ログイン
-              <span className="ml-2 align-baseline text-base font-semibold text-white/85">
+              <span className="ml-2 align-baseline text-base font-semibold text-[#9499C4]">
                 로그인 필요
               </span>
             </h1>
-            <p className="mt-2 text-sm text-white/80">
+            <p className="mt-2 text-sm text-[#BCC0E8]">
               続けるには{" "}
-              <Link className="font-semibold underline" href="/login">
+              <Link className="font-semibold text-[#818cf8] underline underline-offset-2 hover:text-[#60a5fa]" href="/login">
                 ログイン
               </Link>
               してください。
@@ -81,8 +81,8 @@ export default function MePage() {
 
   if (state.status === "loading") {
     return (
-      <div className="flex flex-1 items-center justify-center bg-gradient-to-b from-sky-600 via-teal-500 to-cyan-700 px-4 py-10 text-white">
-        <div className="text-sm text-white/80">読み込み中...</div>
+      <div className="flex flex-1 items-center justify-center bg-[#08091A] px-4 py-10 text-[#F0F0FF]">
+        <div className="text-sm text-[#9499C4]">読み込み中...</div>
       </div>
     );
   }
@@ -140,54 +140,72 @@ export default function MePage() {
     }
   };
 
+  // Derive initials/avatar character
+  const avatarChar = (state.user.nickname ?? state.user.name)?.[0] ?? "U";
+
   return (
-    <div className="min-h-[calc(100vh-56px)] bg-gradient-to-b from-sky-600 via-teal-500 to-cyan-700 px-4 py-8 text-white">
-      <div className="mx-auto w-full max-w-2xl space-y-6">
-        <div className="flex flex-col gap-2">
-          <h1 className="text-3xl font-extrabold tracking-tight text-white drop-shadow-sm sm:text-4xl">
-            プロフィール
-            <span className="ml-2 align-baseline text-lg font-semibold text-white/85">프로필</span>
-          </h1>
-          <p className="text-sm text-white/80">アカウント情報の確認・編集ができます。</p>
+    <div className="relative min-h-[calc(100vh-56px)] overflow-hidden bg-[#08091A] px-4 py-8 text-[#F0F0FF]">
+      <div
+        aria-hidden
+        className="absolute rounded-full pointer-events-none blur-[80px] bg-[rgba(99,102,241,0.12)]"
+        style={{ width: 400, height: 300, top: -60, left: "50%", transform: "translateX(-50%)" }}
+      />
+      <div className="relative mx-auto w-full max-w-2xl space-y-6">
+        {/* Profile avatar */}
+        <div className="flex flex-col items-center gap-3 pb-2">
+          <div
+            className="flex h-20 w-20 items-center justify-center rounded-full text-3xl font-bold text-white shadow-[0_0_32px_rgba(99,102,241,0.4)]"
+            style={{ background: "linear-gradient(135deg,#6366f1,#3b82f6)" }}
+          >
+            {avatarChar}
+          </div>
+          <div className="text-center">
+            <div className="text-xl font-bold text-[#F0F0FF]">
+              {state.user.nickname ?? state.user.name}
+            </div>
+            <div className="text-sm text-[#9499C4]">{state.user.email}</div>
+          </div>
+          <div>
+            <h1 className="sr-only">プロフィール</h1>
+          </div>
         </div>
 
         {!editing ? (
           <Section
             title="アカウント情報"
             subtitle="계정 정보"
-            headerClassName="rounded-2xl bg-white/10 px-4 py-3 ring-1 ring-white/10 backdrop-blur"
-            titleClassName="text-white drop-shadow-sm"
-            descriptionClassName="text-white/80"
+            headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
+            titleClassName="text-[#F0F0FF]"
             right={
-              <Button variant="secondary" type="button" onClick={handleEdit}>
+              <Button variant="ghost" type="button" onClick={handleEdit}>
                 編集
               </Button>
             }
           >
-            <Card className="border-white/10 bg-white/10 text-white backdrop-blur">
+            <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
               <dl className="grid grid-cols-3 gap-3 text-sm">
-                <dt className="text-white/70">ID</dt>
-                <dd className="col-span-2 break-all text-white">{state.user.id}</dd>
-                <dt className="text-white/70">名前</dt>
-                <dd className="col-span-2 text-white">{state.user.name}</dd>
-                <dt className="text-white/70">ニックネーム</dt>
-                <dd className="col-span-2 text-white">
+                <dt className="text-[#9499C4]">ID</dt>
+                <dd className="col-span-2 break-all font-mono text-[#BCC0E8] text-xs">{state.user.id}</dd>
+                <dt className="text-[#9499C4]">名前</dt>
+                <dd className="col-span-2 text-[#F0F0FF]">{state.user.name}</dd>
+                <dt className="text-[#9499C4]">ニックネーム</dt>
+                <dd className="col-span-2 text-[#F0F0FF]">
                   {state.user.nickname ? (
                     state.user.nickname
                   ) : (
-                    <span className="text-white/50">未設定</span>
+                    <span className="text-[#5C6199]">未設定</span>
                   )}
                 </dd>
-                <dt className="text-white/70">メール</dt>
-                <dd className="col-span-2 text-white">{state.user.email}</dd>
+                <dt className="text-[#9499C4]">メール</dt>
+                <dd className="col-span-2 text-[#F0F0FF]">{state.user.email}</dd>
               </dl>
 
               {successMessage && (
-                <p className="mt-4 text-sm font-medium text-green-300">{successMessage}</p>
+                <p className="mt-4 text-sm font-medium text-[#34d399]">{successMessage}</p>
               )}
 
               <div className="mt-4 flex justify-end">
-                <Button type="button" onClick={() => logout()}>
+                <Button variant="danger" type="button" onClick={() => logout()}>
                   ログアウト
                 </Button>
               </div>
@@ -197,10 +215,10 @@ export default function MePage() {
           <Section
             title="プロフィール編集"
             subtitle="프로필 수정"
-            headerClassName="rounded-2xl bg-white/10 px-4 py-3 ring-1 ring-white/10 backdrop-blur"
-            titleClassName="text-white drop-shadow-sm"
+            headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
+            titleClassName="text-[#F0F0FF]"
           >
-            <Card className="border-white/10 bg-white/10 text-white backdrop-blur">
+            <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
               <form onSubmit={handleSubmit} className="flex flex-col gap-4">
                 <Input
                   label="名前"
@@ -230,8 +248,8 @@ export default function MePage() {
                   error={fieldErrors["email"]}
                 />
 
-                <div className="border-t border-white/10 pt-4">
-                  <p className="mb-3 text-xs text-white/60">
+                <div className="border-t border-[rgba(255,255,255,0.06)] pt-4">
+                  <p className="mb-3 text-xs text-[#5C6199]">
                     パスワードを変更する場合のみ入力してください
                   </p>
                   <div className="flex flex-col gap-4">
@@ -268,13 +286,13 @@ export default function MePage() {
                   </div>
                 </div>
 
-                {error && <p className="text-sm text-red-300">{error}</p>}
+                {error && <p className="text-sm text-[#fb7185]">{error}</p>}
 
                 <div className="flex gap-3">
                   <Button type="submit" disabled={submitting}>
                     {submitting ? "保存中..." : "保存"}
                   </Button>
-                  <Button variant="secondary" type="button" onClick={handleCancel}>
+                  <Button variant="ghost" type="button" onClick={handleCancel}>
                     キャンセル
                   </Button>
                 </div>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -12,7 +12,7 @@ export const metadata: Metadata = {
 
 function FeatureCard({
   href,
-  emoji,
+  icon,
   title,
   titleKo,
   children,
@@ -20,7 +20,7 @@ function FeatureCard({
   highlight,
 }: {
   href: string;
-  emoji: string;
+  icon: string;
   title: string;
   titleKo: string;
   children: ReactNode;
@@ -31,23 +31,25 @@ function FeatureCard({
     <Link
       href={href}
       className={[
-        "group relative flex flex-col overflow-hidden rounded-2xl border p-6 text-left shadow-lg transition-all duration-300",
-        "border-white/15 bg-white/10 ring-1 ring-white/10 backdrop-blur-md",
-        "hover:-translate-y-0.5 hover:border-white/25 hover:bg-white/15 hover:shadow-xl",
-        highlight ? "md:ring-2 md:ring-amber-300/40" : "",
+        "group relative flex flex-col overflow-hidden rounded-2xl border p-6 text-left transition-all duration-300",
+        highlight
+          ? "border-[rgba(99,102,241,0.35)] bg-[rgba(99,102,241,0.08)] shadow-[0_0_32px_rgba(99,102,241,0.15),0_8px_32px_rgba(0,0,0,0.4)]"
+          : "border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] shadow-[0_8px_32px_rgba(0,0,0,0.4)]",
+        "backdrop-blur-xl",
+        "hover:-translate-y-0.5 hover:border-[rgba(255,255,255,0.15)] hover:bg-[rgba(255,255,255,0.08)] hover:shadow-[0_12px_40px_rgba(0,0,0,0.5)]",
       ].join(" ")}
     >
       <div
         aria-hidden
-        className="pointer-events-none absolute -right-8 -top-8 h-32 w-32 rounded-full bg-white/10 blur-2xl transition-opacity group-hover:opacity-80"
+        className="pointer-events-none absolute -right-8 -top-8 h-32 w-32 rounded-full bg-[rgba(99,102,241,0.1)] blur-2xl transition-opacity group-hover:opacity-80"
       />
-      <span className="text-3xl drop-shadow-sm">{emoji}</span>
-      <h2 className="mt-3 text-lg font-bold text-white drop-shadow-sm">
+      <span className="text-3xl">{icon}</span>
+      <h2 className="mt-3 text-lg font-bold text-[#F0F0FF]">
         {title}
-        <span className="mt-0.5 block text-sm font-semibold text-white/75">{titleKo}</span>
+        <span className="mt-0.5 block text-sm font-medium text-[#9499C4]">{titleKo}</span>
       </h2>
-      <p className="mt-2 flex-1 text-sm leading-relaxed text-white/80">{children}</p>
-      <span className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-amber-200 group-hover:text-amber-100">
+      <p className="mt-2 flex-1 text-sm leading-relaxed text-[#BCC0E8]">{children}</p>
+      <span className="mt-4 inline-flex items-center gap-1 text-sm font-semibold text-[#818cf8] group-hover:text-[#60a5fa]">
         {cta}
         <span aria-hidden className="transition-transform group-hover:translate-x-0.5">
           →
@@ -59,21 +61,21 @@ function FeatureCard({
 
 function ComingSoonCard({ item }: { item: PlannedFeature }) {
   return (
-    <div className="relative flex flex-col overflow-hidden rounded-2xl border border-violet-300/25 bg-gradient-to-br from-violet-950/50 via-fuchsia-900/35 to-transparent p-5 ring-1 ring-white/10 backdrop-blur-md">
+    <div className="relative flex flex-col overflow-hidden rounded-2xl border border-[rgba(99,102,241,0.2)] bg-[rgba(99,102,241,0.06)] p-5 backdrop-blur-xl shadow-[0_8px_32px_rgba(0,0,0,0.4)]">
       <div className="flex items-start justify-between gap-2">
-        <span className="inline-flex items-center rounded-full bg-amber-400/90 px-2.5 py-0.5 text-[11px] font-bold uppercase tracking-wide text-amber-950">
+        <span className="inline-flex items-center rounded-full bg-[rgba(99,102,241,0.15)] border border-[rgba(99,102,241,0.3)] px-2.5 py-0.5 text-[11px] font-bold uppercase tracking-wide text-[#818cf8]">
           Coming soon
         </span>
         <span aria-hidden className="text-xl opacity-90">
           🚀
         </span>
       </div>
-      <h3 className="mt-3 text-base font-bold text-white drop-shadow-sm">{item.title_ja}</h3>
+      <h3 className="mt-3 text-base font-bold text-[#F0F0FF]">{item.title_ja}</h3>
       {item.subtitle_ko ? (
-        <p className="mt-1 text-xs font-semibold text-fuchsia-100/85">{item.subtitle_ko}</p>
+        <p className="mt-1 text-xs font-medium text-[#818cf8]">{item.subtitle_ko}</p>
       ) : null}
       {item.summary_ja ? (
-        <p className="mt-2 text-sm leading-relaxed text-white/80">{item.summary_ja}</p>
+        <p className="mt-2 text-sm leading-relaxed text-[#BCC0E8]">{item.summary_ja}</p>
       ) : null}
     </div>
   );
@@ -83,38 +85,43 @@ export default async function Home() {
   const plannedFeatures = await listPublishedPlannedFeatures();
 
   return (
-    <div className="relative min-h-[calc(100vh-56px)] overflow-hidden bg-gradient-to-b from-sky-700 via-teal-600 to-cyan-800 px-4 py-12 text-white sm:py-16">
+    <div className="relative min-h-[calc(100vh-56px)] overflow-hidden bg-[#08091A] px-4 py-12 text-[#F0F0FF] sm:py-16">
+      {/* Decorative glow blobs */}
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-0 bg-[radial-gradient(ellipse_80%_50%_at_50%_-20%,rgba(255,255,255,0.22),transparent)]"
+        className="absolute rounded-full pointer-events-none blur-[80px] bg-[rgba(99,102,241,0.12)]"
+        style={{ width: 600, height: 400, top: -100, left: "50%", transform: "translateX(-50%)" }}
       />
       <div
         aria-hidden
-        className="pointer-events-none absolute bottom-0 left-1/2 h-64 w-[120%] -translate-x-1/2 bg-[radial-gradient(closest-side,rgba(34,211,238,0.15),transparent)]"
+        className="absolute rounded-full pointer-events-none blur-[80px] bg-[rgba(59,130,246,0.10)]"
+        style={{ width: 400, height: 300, bottom: 100, right: -100 }}
       />
 
       <div className="relative mx-auto max-w-4xl">
-        <p className="text-center text-xs font-semibold uppercase tracking-[0.2em] text-teal-100/90 sm:text-sm">
+        {/* Hero */}
+        <p className="text-center text-xs font-semibold uppercase tracking-[0.2em] text-[#9499C4] sm:text-sm">
           TOPIK 語彙 × 毎日ちょっとずつ
         </p>
-        <h1 className="mt-3 text-center text-4xl font-extrabold leading-tight tracking-tight drop-shadow-md sm:text-5xl md:text-6xl">
-          今日の一語が、
+        <h1 className="mt-3 text-center text-4xl font-extrabold leading-tight tracking-tight sm:text-5xl md:text-6xl">
+          <span className="bg-[linear-gradient(135deg,#6366f1,#3b82f6)] bg-clip-text text-transparent">今日の一語が、</span>
           <br className="sm:hidden" />
-          あなたの韓国語を動かす
+          <span className="text-[#F0F0FF]">あなたの韓国語を動かす</span>
         </h1>
-        <p className="mx-auto mt-2 max-w-2xl text-center text-lg font-semibold text-teal-50/95 sm:text-xl">
+        <p className="mx-auto mt-2 max-w-2xl text-center text-lg font-semibold text-[#818cf8] sm:text-xl">
           오늘의 단어가 실력을 바꿔요
         </p>
-        <p className="mx-auto mt-5 max-w-xl text-center text-base leading-relaxed text-white/85 sm:text-lg">
+        <p className="mx-auto mt-5 max-w-xl text-center text-base leading-relaxed text-[#BCC0E8] sm:text-lg">
           レベル別の語彙をめくって、覚えて、ブックマークに残す。
-          <span className="font-semibold text-white">わくわくする反復</span>
+          <span className="font-semibold text-[#F0F0FF]">わくわくする反復</span>
           で、試験も会話も近づきます。
         </p>
 
+        {/* Feature grid */}
         <div className="mt-10 grid gap-4 sm:grid-cols-3">
           <FeatureCard
             href="/vocabularies"
-            emoji="📚"
+            icon="📚"
             title="語彙ライブラリ"
             titleKo="단어 라이브러리"
             cta="語彙をさがす"
@@ -123,7 +130,7 @@ export default async function Home() {
           </FeatureCard>
           <FeatureCard
             href="/quiz"
-            emoji="✨"
+            icon="✨"
             title="フラッシュカード"
             titleKo="플래시카드"
             cta="いまクイズを始める"
@@ -133,7 +140,7 @@ export default async function Home() {
           </FeatureCard>
           <FeatureCard
             href="/bookmarks"
-            emoji="🔖"
+            icon="🔖"
             title="ブックマーク"
             titleKo="북마크"
             cta="保存リストを見る"
@@ -145,7 +152,7 @@ export default async function Home() {
         <div className="mt-4 grid gap-4 sm:grid-cols-3">
           <FeatureCard
             href="/topik-practice"
-            emoji="📝"
+            icon="📝"
             title="TOPIK 問題練習"
             titleKo="토픽 문제 연습"
             cta="問題を解いてみる"
@@ -154,21 +161,22 @@ export default async function Home() {
           </FeatureCard>
         </div>
 
+        {/* Coming soon */}
         {plannedFeatures.length > 0 ? (
           <section className="mt-14" aria-labelledby="coming-soon-heading">
             <div className="text-center">
               <h2
                 id="coming-soon-heading"
-                className="text-2xl font-extrabold tracking-tight text-white drop-shadow-sm sm:text-3xl"
+                className="text-2xl font-extrabold tracking-tight text-[#F0F0FF] sm:text-3xl"
               >
                 近日公開
-                <span className="mt-1 block text-base font-semibold text-violet-100/90 sm:text-lg">
+                <span className="mt-1 block text-base font-semibold text-[#818cf8] sm:text-lg">
                   곧 만나요 · Coming soon
                 </span>
               </h2>
-              <p className="mx-auto mt-3 max-w-2xl text-sm leading-relaxed text-white/80 sm:text-base">
+              <p className="mx-auto mt-3 max-w-2xl text-sm leading-relaxed text-[#BCC0E8] sm:text-base">
                 開発チームが準備中の機能です。リリース順は変更になる場合がありますが、
-                <span className="font-medium text-white">どれも「もっと学びたくなる」方向</span>
+                <span className="font-medium text-[#F0F0FF]">どれも「もっと学びたくなる」方向</span>
                 に仕上げていきます。今のうちに会員登録してお待ちください。
               </p>
             </div>
@@ -180,28 +188,29 @@ export default async function Home() {
           </section>
         ) : null}
 
+        {/* CTA buttons */}
         <div className="mt-12 flex flex-col items-center justify-center gap-3 sm:flex-row sm:gap-4">
           <Link
             href="/vocabularies"
-            className="inline-flex min-h-12 w-full max-w-xs items-center justify-center rounded-xl bg-white px-6 py-3 text-base font-bold text-teal-800 shadow-lg transition hover:bg-teal-50 hover:shadow-xl sm:w-auto"
+            className="inline-flex min-h-12 w-full max-w-xs items-center justify-center rounded-xl bg-[linear-gradient(135deg,#6366f1,#3b82f6)] px-6 py-3 text-base font-bold text-white shadow-[0_4px_20px_rgba(99,102,241,0.35)] transition hover:opacity-90 hover:shadow-[0_4px_28px_rgba(99,102,241,0.5)] sm:w-auto"
           >
             はじめてみる
           </Link>
           <Link
             href="/quiz"
-            className="inline-flex min-h-12 w-full max-w-xs items-center justify-center rounded-xl border-2 border-white/50 bg-white/15 px-6 py-3 text-base font-bold text-white backdrop-blur-sm transition hover:border-white/80 hover:bg-white/25 sm:w-auto"
+            className="inline-flex min-h-12 w-full max-w-xs items-center justify-center rounded-xl border border-[rgba(255,255,255,0.12)] bg-[rgba(255,255,255,0.05)] px-6 py-3 text-base font-bold text-[#BCC0E8] backdrop-blur-sm transition hover:border-[rgba(255,255,255,0.2)] hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF] sm:w-auto"
           >
             フラッシュカードへ
           </Link>
         </div>
 
-        <p className="mt-8 text-center text-sm text-white/70">
+        <p className="mt-8 text-center text-sm text-[#5C6199]">
           はじめての方は{" "}
-          <Link href="/register" className="font-semibold text-amber-200 underline decoration-amber-200/60 underline-offset-2 hover:text-amber-100">
+          <Link href="/register" className="font-semibold text-[#818cf8] underline decoration-[rgba(129,140,248,0.6)] underline-offset-2 hover:text-[#60a5fa]">
             無料の会員登録
           </Link>
           {" · "}
-          <Link href="/login" className="font-semibold text-white underline decoration-white/40 underline-offset-2 hover:text-teal-50">
+          <Link href="/login" className="font-semibold text-[#BCC0E8] underline decoration-[rgba(188,192,232,0.4)] underline-offset-2 hover:text-[#F0F0FF]">
             ログイン
           </Link>
         </p>

--- a/frontend/src/app/quiz/page.tsx
+++ b/frontend/src/app/quiz/page.tsx
@@ -39,6 +39,27 @@ function shuffle<T>(arr: T[]): T[] {
   return a;
 }
 
+function LevelBadge({ level }: { level?: number | null }) {
+  if (!level) return null;
+  const colors: Record<number, { bg: string; text: string; border: string }> = {
+    1: { bg: "rgba(16,185,129,0.15)", text: "#34d399", border: "rgba(16,185,129,0.25)" },
+    2: { bg: "rgba(59,130,246,0.15)", text: "#60a5fa", border: "rgba(59,130,246,0.25)" },
+    3: { bg: "rgba(99,102,241,0.15)", text: "#818cf8", border: "rgba(99,102,241,0.25)" },
+    4: { bg: "rgba(99,102,241,0.15)", text: "#818cf8", border: "rgba(99,102,241,0.25)" },
+    5: { bg: "rgba(245,158,11,0.15)", text: "#fbbf24", border: "rgba(245,158,11,0.25)" },
+    6: { bg: "rgba(244,63,94,0.15)", text: "#fb7185", border: "rgba(244,63,94,0.25)" },
+  };
+  const c = colors[level] ?? colors[3];
+  return (
+    <span
+      className="font-mono text-[11px] font-bold uppercase tracking-[0.05em] px-2.5 py-0.5 rounded-full"
+      style={{ background: c.bg, color: c.text, border: `1px solid ${c.border}` }}
+    >
+      LEVEL {level}
+    </span>
+  );
+}
+
 export default function QuizPage() {
   const { state, refreshMe } = useAuth();
 
@@ -53,14 +74,11 @@ export default function QuizPage() {
   // ── quiz state ───────────────────────────────────────────
   const [phase, setPhase] = useState<Phase>("setup");
   const [cards, setCards] = useState<UserVocabulary[]>([]);
-  /** スタート／「もう一度（全問）」時のデッキ。「わからなかっただけ」後も上書きしない */
   const [fullRoundDeck, setFullRoundDeck] = useState<UserVocabulary[]>([]);
   const [index, setIndex] = useState(0);
   const [flipped, setFlipped] = useState(false);
   const [results, setResults] = useState<{ card: UserVocabulary; correct: boolean }[]>([]);
-  /** カードインデックスごとの自己評価。前後ナビゲーション時も保持する */
   const [cardAnswers, setCardAnswers] = useState<Record<number, boolean>>({});
-  /** めくり済みカードのインデックスセット。前後ナビ時に状態を復元するために使用 */
   const [cardFlipped, setCardFlipped] = useState<Set<number>>(new Set());
 
   // ── bookmark state (results screen) ─────────────────────
@@ -71,7 +89,6 @@ export default function QuizPage() {
     if (state.status === "loading") refreshMe().catch(() => undefined);
   }, [refreshMe, state.status]);
 
-  // 結果画面表示時にブックマーク済み語彙を取得する
   useEffect(() => {
     if (phase !== "finished" || state.status !== "authed") return;
     const run = async () => {
@@ -79,7 +96,7 @@ export default function QuizPage() {
         const res = await listBookmarks(state.token);
         setBookmarkedIds(new Set(res.bookmarks.map((b) => b.id)));
       } catch {
-        // ブックマーク状態の取得失敗は無視（ボタン表示には影響しない）
+        // ignore
       }
     };
     run().catch(() => undefined);
@@ -226,8 +243,8 @@ export default function QuizPage() {
 
   if (state.status === "loading") {
     return (
-      <div className="flex flex-1 items-center justify-center bg-gradient-to-b from-sky-600 via-teal-500 to-cyan-700 px-4 py-10">
-        <div className="text-sm text-white/80">読み込み中...</div>
+      <div className="flex flex-1 items-center justify-center bg-[#08091A] px-4 py-10">
+        <div className="text-sm text-[#9499C4]">読み込み中...</div>
       </div>
     );
   }
@@ -237,14 +254,19 @@ export default function QuizPage() {
   // ════════════════════════════════════════
   if (phase === "setup") {
     return (
-      <div className="min-h-[calc(100vh-56px)] bg-gradient-to-b from-sky-600 via-teal-500 to-cyan-700 px-4 py-8 text-white">
-        <div className="mx-auto w-full max-w-lg space-y-6">
+      <div className="relative min-h-[calc(100vh-56px)] overflow-hidden bg-[#08091A] px-4 py-8 text-[#F0F0FF]">
+        <div
+          aria-hidden
+          className="absolute rounded-full pointer-events-none blur-[80px] bg-[rgba(99,102,241,0.12)]"
+          style={{ width: 500, height: 300, top: -50, left: "50%", transform: "translateX(-50%)" }}
+        />
+        <div className="relative mx-auto w-full max-w-lg space-y-6">
           <div>
-            <h1 className="text-3xl font-extrabold tracking-tight drop-shadow-sm sm:text-4xl">
+            <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
               フラッシュカード
-              <span className="ml-2 align-baseline text-lg font-semibold text-white/85">플래시카드</span>
+              <span className="ml-2 align-baseline text-lg font-semibold text-[#9499C4]">플래시카드</span>
             </h1>
-            <p className="mt-1 text-sm text-white/80">
+            <p className="mt-1 text-sm text-[#9499C4]">
               ランダム出題。答えを見てから「わからない」「わかった」で次へ進みます。
             </p>
           </div>
@@ -252,14 +274,14 @@ export default function QuizPage() {
           <Section
             title="設定"
             subtitle="설정"
-            headerClassName="rounded-2xl bg-white/10 px-4 py-3 ring-1 ring-white/10 backdrop-blur"
-            titleClassName="text-white drop-shadow-sm"
+            headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
+            titleClassName="text-[#F0F0FF]"
           >
-            <Card className="space-y-5 border-white/10 bg-white/10 text-white backdrop-blur">
+            <Card className="space-y-5 border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
               {/* 出題モード */}
               <div>
-                <div className="text-sm font-semibold text-white">
-                  出題モード <span className="ml-1 text-white/70">출제 방향</span>
+                <div className="text-sm font-semibold text-[#BCC0E8]">
+                  出題モード <span className="ml-1 text-[#5C6199]">출제 방향</span>
                 </div>
                 <div className="mt-2 flex gap-2">
                   <Chip
@@ -281,8 +303,8 @@ export default function QuizPage() {
 
               {/* 出題元 */}
               <div>
-                <div className="text-sm font-semibold text-white">
-                  出題元 <span className="ml-1 text-white/70">출제 범위</span>
+                <div className="text-sm font-semibold text-[#BCC0E8]">
+                  出題元 <span className="ml-1 text-[#5C6199]">출제 범위</span>
                 </div>
                 <div className="mt-2 flex gap-2">
                   <Chip
@@ -307,19 +329,19 @@ export default function QuizPage() {
                   </Chip>
                 </div>
                 {state.status === "guest" && source === "bookmarks" ? (
-                  <div className="mt-3 rounded-xl border border-amber-300/35 bg-amber-500/15 px-3 py-3 text-sm leading-relaxed text-white/95 ring-1 ring-amber-200/20">
-                    <p className="font-semibold text-amber-50">会員登録でご利用いただけます</p>
-                    <p className="mt-1.5 text-white/85">
+                  <div className="mt-3 rounded-xl border border-[rgba(99,102,241,0.3)] bg-[rgba(99,102,241,0.08)] px-3 py-3 text-sm leading-relaxed text-[#BCC0E8]">
+                    <p className="font-semibold text-[#818cf8]">会員登録でご利用いただけます</p>
+                    <p className="mt-1.5 text-[#BCC0E8]">
                       ブックマークに保存した語彙だけを出題するには、
-                      <strong className="text-white">無料の会員登録</strong>
+                      <strong className="text-[#F0F0FF]">無料の会員登録</strong>
                       が必要です。登録後はログインしてお楽しみください。
                     </p>
                     <p className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-sm">
-                      <Link className="font-semibold text-white underline underline-offset-2" href="/register">
+                      <Link className="font-semibold text-[#818cf8] underline underline-offset-2" href="/register">
                         会員登録（無料）
                       </Link>
-                      <span className="text-white/50">|</span>
-                      <Link className="font-semibold text-white/90 underline underline-offset-2" href="/login">
+                      <span className="text-[#5C6199]">|</span>
+                      <Link className="font-semibold text-[#BCC0E8] underline underline-offset-2" href="/login">
                         ログイン
                       </Link>
                     </p>
@@ -327,11 +349,11 @@ export default function QuizPage() {
                 ) : null}
               </div>
 
-              {/* レベル絞り込み（全語彙のみ） */}
+              {/* レベル絞り込み */}
               {source === "all" ? (
                 <div>
-                  <div className="text-sm font-semibold text-white">
-                    TOPIK レベル <span className="ml-1 text-white/70">토픽 레벨</span>
+                  <div className="text-sm font-semibold text-[#BCC0E8]">
+                    TOPIK レベル <span className="ml-1 text-[#5C6199]">토픽 레벨</span>
                   </div>
                   <div className="mt-2 flex flex-wrap gap-2">
                     {LEVEL_OPTIONS.map((o) => (
@@ -350,8 +372,8 @@ export default function QuizPage() {
 
               {/* 問題数 */}
               <div>
-                <div className="text-sm font-semibold text-white">
-                  問題数 <span className="ml-1 text-white/70">문제 수</span>
+                <div className="text-sm font-semibold text-[#BCC0E8]">
+                  問題数 <span className="ml-1 text-[#5C6199]">문제 수</span>
                 </div>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {COUNT_OPTIONS.map((o) => (
@@ -368,7 +390,7 @@ export default function QuizPage() {
               </div>
 
               {loadError ? (
-                <div className="text-sm font-medium text-red-200">{loadError}</div>
+                <div className="text-sm font-medium text-[#fb7185]">{loadError}</div>
               ) : null}
 
               <Button
@@ -396,28 +418,37 @@ export default function QuizPage() {
     const answer1 = mode === "kr-to-ja" ? card.meaning_ja : card.term;
 
     return (
-      <div className="min-h-[calc(100vh-56px)] bg-gradient-to-b from-sky-600 via-teal-500 to-cyan-700 px-4 py-8 text-white">
-        <div className="mx-auto w-full max-w-lg space-y-5">
+      <div className="relative min-h-[calc(100vh-56px)] overflow-hidden bg-[#08091A] px-4 py-8 text-[#F0F0FF]">
+        <div
+          aria-hidden
+          className="absolute rounded-full pointer-events-none blur-[80px] bg-[rgba(99,102,241,0.12)]"
+          style={{ width: 400, height: 300, top: -80, left: "30%", transform: "translateX(-50%)" }}
+        />
+        <div className="relative mx-auto w-full max-w-lg space-y-5">
           {/* ヘッダー */}
           <div className="flex items-center justify-between">
             <button
               type="button"
               onClick={() => setPhase("setup")}
-              className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1.5 text-sm font-medium ring-1 ring-white/25 hover:bg-white/15"
+              className="inline-flex items-center gap-2 rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-3 py-1.5 text-sm font-medium text-[#BCC0E8] hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF]"
             >
               <span aria-hidden="true">←</span>
               設定に戻る
             </button>
-            <div className="text-sm font-semibold text-white/80">
-              {index + 1} / {cards.length}
+            <div className="flex items-center gap-3">
+              <span className="font-mono text-xs text-[#5C6199]">{index + 1} / {cards.length}</span>
+              <LevelBadge level={card.level} />
             </div>
           </div>
 
           {/* プログレスバー */}
-          <div className="h-2 w-full overflow-hidden rounded-full bg-white/20">
+          <div className="h-1 w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
             <div
-              className="h-full rounded-full bg-white/70 transition-all duration-300"
-              style={{ width: `${progress}%` }}
+              className="h-full rounded-full transition-all duration-300"
+              style={{
+                width: `${progress}%`,
+                background: "linear-gradient(90deg, #6366f1, #3b82f6)",
+              }}
             />
           </div>
 
@@ -433,80 +464,70 @@ export default function QuizPage() {
               aria-pressed={flipped}
               aria-label={flipped ? "答え表示済み" : "カードをめくって答えを表示"}
               className={[
-                "group relative block w-full min-h-[13.5rem] rounded-2xl p-0 text-left",
-                "outline-none focus-visible:ring-2 focus-visible:ring-white/70 focus-visible:ring-offset-2 focus-visible:ring-offset-teal-600/80",
+                "group relative block w-full min-h-[14rem] rounded-2xl p-0 text-left",
+                "outline-none focus-visible:ring-2 focus-visible:ring-[rgba(99,102,241,0.7)] focus-visible:ring-offset-2 focus-visible:ring-offset-[#08091A]",
                 flipped ? "cursor-default" : "cursor-pointer",
               ].join(" ")}
             >
               <div
                 key={card.id}
-                className="relative min-h-[13.5rem] w-full [transform-style:preserve-3d] will-change-transform"
+                className="relative min-h-[14rem] w-full [transform-style:preserve-3d] will-change-transform"
                 style={{
                   transform: flipped ? "rotateY(180deg)" : "rotateY(0deg)",
-                  transition: "transform 0.65s cubic-bezier(0.4, 0.15, 0.2, 1)",
+                  transition: "transform 0.6s cubic-bezier(0.4, 0, 0.2, 1)",
                 }}
               >
                 {/* 表面（問題） */}
                 <div
                   className={[
-                    "absolute inset-0 flex min-h-[13.5rem] flex-col items-center justify-center gap-4 overflow-hidden rounded-2xl px-4 py-8 text-center",
-                    "border border-white/20 bg-gradient-to-br from-white/20 via-white/10 to-teal-900/30",
-                    "shadow-[0_22px_48px_-12px_rgba(0,0,0,0.45),inset_0_1px_0_rgba(255,255,255,0.35)]",
-                    "backdrop-blur-md [backface-visibility:hidden] [transform:translateZ(0.1px)]",
-                    "ring-1 ring-white/10",
+                    "absolute inset-0 flex min-h-[14rem] flex-col items-center justify-center gap-4 overflow-hidden rounded-2xl px-4 py-8 text-center",
+                    "border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)]",
+                    "shadow-[0_8px_32px_rgba(0,0,0,0.4)]",
+                    "backdrop-blur-xl [backface-visibility:hidden] [transform:translateZ(0.1px)]",
                   ].join(" ")}
                 >
-                  <div
-                    aria-hidden
-                    className="pointer-events-none absolute inset-0 bg-gradient-to-tr from-transparent via-white/5 to-white/20 opacity-70"
-                  />
-                  <div className="relative text-xs font-semibold tracking-wide text-white/55">
+                  <div className="text-xs font-semibold tracking-wide text-[#5C6199]">
                     {card.level_label_ja}
                   </div>
-                  <div className="relative text-4xl font-extrabold tracking-tight text-white drop-shadow-md sm:text-5xl">
+                  <div className="text-4xl font-extrabold tracking-tight text-[#F0F0FF] sm:text-5xl">
                     {question}
                   </div>
-                  <div className="relative px-2" onClick={(e) => e.stopPropagation()}>
+                  <div className="px-2" onClick={(e) => e.stopPropagation()}>
                     <VocabularyAudioPlayButton
                       vocabularyId={card.id}
                       initialAudioUrl={card.audio_url}
                       avoidNestedButton
                     />
                   </div>
-                  <div className="relative text-sm text-white/65">
+                  <div className="text-sm text-[#5C6199]">
                     タップでめくる
-                    <span className="mt-1 block text-xs text-white/45">탭하여 뒤집기</span>
+                    <span className="mt-1 block text-xs text-[#5C6199]">탭하여 뒤집기</span>
                   </div>
                 </div>
+
                 {/* 裏面（答え） */}
                 <div
                   className={[
-                    "absolute inset-0 flex min-h-[13.5rem] flex-col items-center justify-center gap-3 overflow-y-auto rounded-2xl px-4 py-8 text-center",
-                    "border border-emerald-200/25 bg-gradient-to-br from-teal-900/85 via-teal-800/70 to-sky-900/80",
-                    "shadow-[0_22px_48px_-12px_rgba(0,0,0,0.5),inset_0_1px_0_rgba(255,255,255,0.12)]",
-                    "backdrop-blur-md [backface-visibility:hidden] [transform:rotateY(180deg)_translateZ(0.1px)]",
-                    "ring-1 ring-emerald-300/15",
+                    "absolute inset-0 flex min-h-[14rem] flex-col items-center justify-center gap-3 overflow-y-auto rounded-2xl px-4 py-8 text-center",
+                    "border border-[rgba(99,102,241,0.25)] backdrop-blur-xl",
+                    "[backface-visibility:hidden] [transform:rotateY(180deg)_translateZ(0.1px)]",
+                    "shadow-[0_0_24px_rgba(99,102,241,0.2),0_8px_32px_rgba(0,0,0,0.4)]",
                   ].join(" ")}
+                  style={{ background: "linear-gradient(135deg, rgba(99,102,241,0.12), rgba(59,130,246,0.08))" }}
                 >
-                  <div
-                    aria-hidden
-                    className="pointer-events-none absolute inset-0 bg-gradient-to-bl from-white/10 via-transparent to-black/20"
-                  />
-                  <div className="relative text-xs font-semibold text-emerald-100/70">
+                  <div className="text-xs font-semibold text-[#9499C4]">
                     {card.level_label_ja}
                   </div>
-                  <div className="relative text-2xl font-bold text-white/80">{question}</div>
-                  <div className="relative text-3xl font-extrabold text-white drop-shadow-md sm:text-4xl">
-                    {answer1}
-                  </div>
+                  <div className="text-xl font-bold text-[#BCC0E8]">{question}</div>
+                  <div className="text-3xl font-extrabold text-[#F0F0FF] sm:text-4xl">{answer1}</div>
                   {card.example_sentence ? (
-                    <div className="relative mt-1 max-w-xs space-y-1.5 text-base leading-snug text-white/80">
+                    <div className="mt-1 max-w-xs space-y-1.5 text-base leading-snug text-[#BCC0E8]">
                       <div className="flex gap-1.5">
                         <span aria-hidden>🇰🇷</span>
                         <span>
                           <HighlightedExampleText
                             text={card.example_sentence}
-                            markClassName="font-semibold text-white underline decoration-amber-200/90 decoration-2 underline-offset-[0.2em]"
+                            markClassName="font-semibold text-[#F0F0FF] underline decoration-[#818cf8]/90 decoration-2 underline-offset-[0.2em]"
                           />
                         </span>
                       </div>
@@ -516,7 +537,7 @@ export default function QuizPage() {
                           <span>
                             <HighlightedExampleText
                               text={card.example_translation_ja}
-                              markClassName="font-semibold text-white/95 underline decoration-emerald-200/85 decoration-2 underline-offset-[0.2em]"
+                              markClassName="font-semibold text-[#F0F0FF]/95 underline decoration-[#60a5fa]/85 decoration-2 underline-offset-[0.2em]"
                             />
                           </span>
                         </div>
@@ -528,26 +549,24 @@ export default function QuizPage() {
             </button>
           </div>
 
-          {/* 自己評価（次のカードへ） */}
+          {/* 自己評価 */}
           {flipped ? (
             <div className="grid grid-cols-2 gap-3">
               <button
                 type="button"
                 onClick={() => answer(false)}
-                className="rounded-xl bg-red-500/30 px-4 py-4 text-center font-semibold text-white ring-1 ring-red-400/40 transition-colors hover:bg-red-500/40"
+                className="rounded-xl border border-[rgba(244,63,94,0.25)] bg-[rgba(244,63,94,0.12)] px-4 py-4 text-center font-semibold text-[#fb7185] transition-colors hover:bg-[rgba(244,63,94,0.2)]"
               >
-                <div className="text-xl">🤔</div>
-                <div className="mt-1 text-sm">わからない</div>
-                <div className="text-xs text-white/70">모르겠어요</div>
+                <div className="text-sm">몰랐어요</div>
+                <div className="mt-0.5 text-xs text-[rgba(251,113,133,0.7)]">わからない</div>
               </button>
               <button
                 type="button"
                 onClick={() => answer(true)}
-                className="rounded-xl bg-emerald-500/30 px-4 py-4 text-center font-semibold text-white ring-1 ring-emerald-400/40 transition-colors hover:bg-emerald-500/40"
+                className="rounded-xl border border-[rgba(16,185,129,0.25)] bg-[rgba(16,185,129,0.12)] px-4 py-4 text-center font-semibold text-[#34d399] transition-colors hover:bg-[rgba(16,185,129,0.2)]"
               >
-                <div className="text-xl">✅</div>
-                <div className="mt-1 text-sm">わかった</div>
-                <div className="text-xs text-white/70">알겠어요</div>
+                <div className="text-sm">알겠어요!</div>
+                <div className="mt-0.5 text-xs text-[rgba(52,211,153,0.7)]">わかった</div>
               </button>
             </div>
           ) : (
@@ -561,10 +580,10 @@ export default function QuizPage() {
               onClick={goBack}
               disabled={index === 0}
               className={[
-                "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium ring-1 transition-colors",
+                "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium border transition-colors",
                 index === 0
-                  ? "cursor-not-allowed bg-white/5 text-white/30 ring-white/10"
-                  : "bg-white/10 text-white ring-white/25 hover:bg-white/15",
+                  ? "cursor-not-allowed border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.02)] text-[#5C6199]"
+                  : "border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#BCC0E8] hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF]",
               ].join(" ")}
             >
               <span aria-hidden="true">←</span>
@@ -574,7 +593,7 @@ export default function QuizPage() {
               <button
                 type="button"
                 onClick={goForward}
-                className="inline-flex items-center gap-1.5 rounded-full bg-white/10 px-3 py-1.5 text-sm font-medium ring-1 ring-white/25 transition-colors hover:bg-white/15"
+                className="inline-flex items-center gap-1.5 rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-3 py-1.5 text-sm font-medium text-[#BCC0E8] transition-colors hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF]"
               >
                 次の問題
                 <span aria-hidden="true">→</span>
@@ -595,55 +614,71 @@ export default function QuizPage() {
   const scorePercent = Math.round((correctCount / results.length) * 100);
 
   return (
-    <div className="min-h-[calc(100vh-56px)] bg-gradient-to-b from-sky-600 via-teal-500 to-cyan-700 px-4 py-8 text-white">
-      <div className="mx-auto w-full max-w-lg space-y-6">
-        <div>
-          <h1 className="text-3xl font-extrabold tracking-tight drop-shadow-sm">
-            結果
-            <span className="ml-2 align-baseline text-lg font-semibold text-white/85">결과</span>
-          </h1>
-        </div>
+    <div className="relative min-h-[calc(100vh-56px)] overflow-hidden bg-[#08091A] px-4 py-8 text-[#F0F0FF]">
+      <div
+        aria-hidden
+        className="absolute rounded-full pointer-events-none blur-[80px] bg-[rgba(99,102,241,0.12)]"
+        style={{ width: 500, height: 300, top: -80, left: "50%", transform: "translateX(-50%)" }}
+      />
+      <div className="relative mx-auto w-full max-w-lg space-y-6">
+        <h1 className="text-3xl font-extrabold tracking-tight">
+          結果
+          <span className="ml-2 align-baseline text-lg font-semibold text-[#9499C4]">결과</span>
+        </h1>
 
         {/* スコア */}
-        <Card className="border-white/10 bg-white/10 text-center text-white backdrop-blur">
-          <div className="py-4">
-            <div className="text-6xl font-extrabold drop-shadow-sm">{scorePercent}%</div>
-            <div className="mt-2 text-lg font-semibold text-white/80">
-              {results.length}問中「わかった」{correctCount}問
-            </div>
-            <div className="text-sm text-white/60">
-              {results.length}문제 중 「알겠어요」 {correctCount}문제
-            </div>
+        <div
+          className="rounded-2xl border border-[rgba(99,102,241,0.25)] p-8 text-center backdrop-blur-xl shadow-[0_0_24px_rgba(99,102,241,0.15),0_8px_32px_rgba(0,0,0,0.4)]"
+          style={{ background: "linear-gradient(135deg, rgba(99,102,241,0.1), rgba(59,130,246,0.06))" }}
+        >
+          <div
+            className="text-6xl font-extrabold"
+            style={{ background: "linear-gradient(135deg,#6366f1,#3b82f6)", WebkitBackgroundClip: "text", WebkitTextFillColor: "transparent", backgroundClip: "text" }}
+          >
+            {scorePercent}%
           </div>
-        </Card>
+          <div className="mt-2 text-lg font-semibold text-[#BCC0E8]">
+            {results.length}問中「わかった」{correctCount}問
+          </div>
+          <div className="mt-3 h-1.5 w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
+            <div
+              className="h-full rounded-full"
+              style={{
+                width: `${scorePercent}%`,
+                background: "linear-gradient(90deg, #6366f1, #3b82f6)",
+                transition: "width 400ms ease-out",
+              }}
+            />
+          </div>
+        </div>
 
         {/* アクションボタン */}
         <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
           <button
             type="button"
             onClick={() => retry(false)}
-            className="rounded-xl bg-white/10 px-4 py-3 text-sm font-semibold text-white ring-1 ring-white/25 hover:bg-white/15"
+            className="rounded-xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 text-sm font-semibold text-[#BCC0E8] hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF]"
           >
             🔄 もう一度
-            <div className="text-xs font-normal text-white/70">처음부터</div>
+            <div className="text-xs font-normal text-[#5C6199]">처음부터</div>
           </button>
           {wrongCards.length > 0 ? (
             <button
               type="button"
               onClick={() => retry(true)}
-              className="rounded-xl bg-red-500/20 px-4 py-3 text-sm font-semibold text-white ring-1 ring-red-400/30 hover:bg-red-500/30"
+              className="rounded-xl border border-[rgba(244,63,94,0.25)] bg-[rgba(244,63,94,0.1)] px-4 py-3 text-sm font-semibold text-[#fb7185] hover:bg-[rgba(244,63,94,0.15)]"
             >
-              🤔 わからなかった {wrongCards.length}問
-              <div className="text-xs font-normal text-white/70">모르겠던 것만</div>
+              わからなかった {wrongCards.length}問
+              <div className="text-xs font-normal text-[rgba(251,113,133,0.7)]">모르겠던 것만</div>
             </button>
           ) : null}
           <button
             type="button"
             onClick={() => setPhase("setup")}
-            className="rounded-xl bg-white/10 px-4 py-3 text-sm font-semibold text-white ring-1 ring-white/25 hover:bg-white/15"
+            className="rounded-xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 text-sm font-semibold text-[#BCC0E8] hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF]"
           >
-            ⚙️ 設定に戻る
-            <div className="text-xs font-normal text-white/70">설정으로</div>
+            設定に戻る
+            <div className="text-xs font-normal text-[#5C6199]">설정으로</div>
           </button>
         </div>
 
@@ -652,19 +687,22 @@ export default function QuizPage() {
           <Section
             title="わからなかった語彙"
             subtitle="모르겠던 단어"
-            headerClassName="rounded-2xl bg-white/10 px-4 py-3 ring-1 ring-white/10 backdrop-blur"
-            titleClassName="text-white drop-shadow-sm"
+            headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
+            titleClassName="text-[#F0F0FF]"
           >
             <div className="space-y-2">
               {wrongCards.map(({ card }) => (
-                <Card key={card.id} className="border-white/10 bg-white/10 text-white backdrop-blur">
+                <div
+                  key={card.id}
+                  className="rounded-xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] p-4 backdrop-blur-xl"
+                >
                   <div className="flex items-center justify-between gap-3">
                     <Link href={`/vocabularies/${card.id}`} className="min-w-0 flex-1">
-                      <div className="font-bold hover:underline">{card.term}</div>
-                      <div className="text-sm text-white/70">{card.meaning_ja}</div>
+                      <div className="font-bold text-[#F0F0FF] hover:text-[#818cf8] hover:underline">{card.term}</div>
+                      <div className="text-sm text-[#9499C4]">{card.meaning_ja}</div>
                     </Link>
                     <div className="flex shrink-0 items-center gap-2">
-                      <div className="text-xs text-white/60">{card.level_label_ja}</div>
+                      <span className="font-mono text-xs text-[#5C6199]">{card.level_label_ja}</span>
                       {state.status === "authed" ? (
                         <button
                           type="button"
@@ -672,10 +710,10 @@ export default function QuizPage() {
                           onClick={() => handleBookmarkToggle(card.id)}
                           title={bookmarkedIds.has(card.id) ? "ブックマーク解除" : "ブックマークに追加"}
                           className={[
-                            "inline-flex items-center rounded-full px-2.5 py-1 text-sm ring-1 transition-colors",
+                            "inline-flex items-center rounded-full px-2.5 py-1 text-sm border transition-colors",
                             bookmarkedIds.has(card.id)
-                              ? "bg-white/20 ring-white/30 hover:bg-white/30"
-                              : "bg-white/10 ring-white/20 hover:bg-white/15",
+                              ? "border-[rgba(99,102,241,0.3)] bg-[rgba(99,102,241,0.15)] hover:bg-[rgba(99,102,241,0.25)]"
+                              : "border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] hover:bg-[rgba(255,255,255,0.1)]",
                             bookmarkBusy.has(card.id) ? "opacity-50" : "",
                           ].join(" ")}
                         >
@@ -686,19 +724,19 @@ export default function QuizPage() {
                           type="button"
                           disabled
                           title="会員登録が必要です"
-                          className="inline-flex cursor-not-allowed items-center rounded-full bg-white/10 px-2.5 py-1 text-sm text-white/40 ring-1 ring-white/15"
+                          className="inline-flex cursor-not-allowed items-center rounded-full border border-[rgba(255,255,255,0.05)] bg-[rgba(255,255,255,0.03)] px-2.5 py-1 text-sm text-[#5C6199]"
                         >
                           🏷️
                         </button>
                       ) : null}
                     </div>
                   </div>
-                </Card>
+                </div>
               ))}
             </div>
             {state.status === "guest" ? (
-              <p className="mt-3 text-center text-xs text-white/65">
-                <Link href="/login" className="underline underline-offset-2 hover:text-white/90">
+              <p className="mt-3 text-center text-xs text-[#5C6199]">
+                <Link href="/login" className="text-[#818cf8] underline underline-offset-2 hover:text-[#60a5fa]">
                   ログイン
                 </Link>
                 するとブックマークに即時保存できます
@@ -706,9 +744,9 @@ export default function QuizPage() {
             ) : null}
           </Section>
         ) : (
-          <Card className="border-white/10 bg-emerald-500/20 text-center text-white backdrop-blur ring-1 ring-emerald-400/30">
-            <div className="py-2 text-sm font-semibold">🎉 すべて「わかった」です！완벽해요!</div>
-          </Card>
+          <div className="rounded-xl border border-[rgba(16,185,129,0.25)] bg-[rgba(16,185,129,0.1)] p-4 text-center text-sm font-semibold text-[#34d399] backdrop-blur-xl">
+            🎉 すべて「わかった」です！완벽해요!
+          </div>
         )}
       </div>
     </div>

--- a/frontend/src/app/topik-practice/page.tsx
+++ b/frontend/src/app/topik-practice/page.tsx
@@ -38,7 +38,6 @@ function shuffle<T>(arr: T[]): T[] {
   return a;
 }
 
-/** 問題文内の「( )」を強調スパンに変換する（文法問題用） */
 function renderGrammarQuestionText(text: string) {
   const parts = text.split("( )");
   return (
@@ -47,7 +46,7 @@ function renderGrammarQuestionText(text: string) {
         <span key={i}>
           {part}
           {i < parts.length - 1 && (
-            <span className="mx-0.5 inline-block min-w-[3rem] rounded border border-white/50 bg-white/20 px-3 py-0.5 text-center font-bold tracking-wider text-amber-200">
+            <span className="mx-0.5 inline-block min-w-[3rem] rounded border border-[rgba(99,102,241,0.4)] bg-[rgba(99,102,241,0.12)] px-3 py-0.5 text-center font-bold tracking-wider text-[#818cf8]">
               （　　）
             </span>
           )}
@@ -57,12 +56,10 @@ function renderGrammarQuestionText(text: string) {
   );
 }
 
-/** ブラウザが Web Speech API をサポートしているか確認する */
 function isSpeechSupported(): boolean {
   return typeof window !== "undefined" && typeof window.SpeechSynthesisUtterance !== "undefined";
 }
 
-/** 韓国語テキストを音声で読み上げる（Web Speech API 使用） */
 function speakKorean(text: string) {
   if (!isSpeechSupported()) return;
   window.speechSynthesis.cancel();
@@ -72,7 +69,6 @@ function speakKorean(text: string) {
   window.speechSynthesis.speak(utter);
 }
 
-/** 音声再生用のアイコン */
 function PlayGlyph({ className }: { className?: string }) {
   return (
     <svg className={className} viewBox="0 0 24 24" fill="currentColor" aria-hidden>
@@ -81,7 +77,6 @@ function PlayGlyph({ className }: { className?: string }) {
   );
 }
 
-/** 回答済みの場合は正解を含む読み上げテキストを、未回答の場合は問題文のみを返す */
 function buildSpeakText(q: TopikQuestion, answered: boolean): string {
   if (!answered) return q.question_text;
   const correctOpt = q.options.find((o) => o.option_number === q.correct_option_number);
@@ -93,14 +88,12 @@ function buildSpeakText(q: TopikQuestion, answered: boolean): string {
 }
 
 export default function TopikPracticePage() {
-  // ── setup state ──────────────────────────────────────────
   const [levelFilter, setLevelFilter] = useState("");
   const [typeFilter, setTypeFilter] = useState("");
   const [count, setCount] = useState(10);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loading, setLoading] = useState(false);
 
-  // ── quiz state ───────────────────────────────────────────
   const [phase, setPhase] = useState<Phase>("setup");
   const [questions, setQuestions] = useState<TopikQuestion[]>([]);
   const [index, setIndex] = useState(0);
@@ -179,14 +172,19 @@ export default function TopikPracticePage() {
   // ════════════════════════════════════════
   if (phase === "setup") {
     return (
-      <div className="min-h-[calc(100vh-56px)] bg-gradient-to-b from-violet-700 via-purple-600 to-indigo-700 px-4 py-8 text-white">
-        <div className="mx-auto w-full max-w-lg space-y-6">
+      <div className="relative min-h-[calc(100vh-56px)] overflow-hidden bg-[#08091A] px-4 py-8 text-[#F0F0FF]">
+        <div
+          aria-hidden
+          className="absolute rounded-full pointer-events-none blur-[80px] bg-[rgba(99,102,241,0.12)]"
+          style={{ width: 500, height: 300, top: -60, left: "50%", transform: "translateX(-50%)" }}
+        />
+        <div className="relative mx-auto w-full max-w-lg space-y-6">
           <div>
-            <h1 className="text-3xl font-extrabold tracking-tight drop-shadow-sm sm:text-4xl">
+            <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
               TOPIK 問題練習
-              <span className="ml-2 align-baseline text-lg font-semibold text-white/85">문제 연습</span>
+              <span className="ml-2 align-baseline text-lg font-semibold text-[#9499C4]">문제 연습</span>
             </h1>
-            <p className="mt-1 text-sm text-white/80">
+            <p className="mt-1 text-sm text-[#9499C4]">
               文法の空欄補充問題（TOPIK 1 の31〜37番形式）。選択肢から正解を選んでください。
             </p>
           </div>
@@ -194,14 +192,14 @@ export default function TopikPracticePage() {
           <Section
             title="設定"
             subtitle="설정"
-            headerClassName="rounded-2xl bg-white/10 px-4 py-3 ring-1 ring-white/10 backdrop-blur"
-            titleClassName="text-white drop-shadow-sm"
+            headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
+            titleClassName="text-[#F0F0FF]"
           >
-            <Card className="space-y-5 border-white/10 bg-white/10 text-white backdrop-blur">
-              {/* 問題タイプ絞り込み */}
+            <Card className="space-y-5 border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
+              {/* 問題タイプ */}
               <div>
-                <div className="text-sm font-semibold text-white">
-                  問題タイプ <span className="ml-1 text-white/70">문제 유형</span>
+                <div className="text-sm font-semibold text-[#BCC0E8]">
+                  問題タイプ <span className="ml-1 text-[#5C6199]">문제 유형</span>
                 </div>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {TYPE_OPTIONS.map((o) => (
@@ -217,10 +215,10 @@ export default function TopikPracticePage() {
                 </div>
               </div>
 
-              {/* レベル絞り込み */}
+              {/* レベル */}
               <div>
-                <div className="text-sm font-semibold text-white">
-                  TOPIK レベル <span className="ml-1 text-white/70">토픽 레벨</span>
+                <div className="text-sm font-semibold text-[#BCC0E8]">
+                  TOPIK レベル <span className="ml-1 text-[#5C6199]">토픽 레벨</span>
                 </div>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {LEVEL_OPTIONS.map((o) => (
@@ -238,8 +236,8 @@ export default function TopikPracticePage() {
 
               {/* 問題数 */}
               <div>
-                <div className="text-sm font-semibold text-white">
-                  問題数 <span className="ml-1 text-white/70">문제 수</span>
+                <div className="text-sm font-semibold text-[#BCC0E8]">
+                  問題数 <span className="ml-1 text-[#5C6199]">문제 수</span>
                 </div>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {COUNT_OPTIONS.map((o) => (
@@ -256,7 +254,7 @@ export default function TopikPracticePage() {
               </div>
 
               {loadError ? (
-                <div className="text-sm font-medium text-red-200">{loadError}</div>
+                <div className="text-sm font-medium text-[#fb7185]">{loadError}</div>
               ) : null}
 
               <Button className="w-full" type="button" disabled={loading} onClick={startQuiz}>
@@ -266,7 +264,7 @@ export default function TopikPracticePage() {
           </Section>
 
           <div className="text-center">
-            <Link href="/quiz" className="text-sm text-white/70 underline underline-offset-2 hover:text-white/90">
+            <Link href="/quiz" className="text-sm text-[#5C6199] underline underline-offset-2 hover:text-[#9499C4]">
               ← 語彙フラッシュカードへ
             </Link>
           </div>
@@ -285,70 +283,78 @@ export default function TopikPracticePage() {
     const isCorrect = isAnswered && selectedOption === q.correct_option_number;
 
     return (
-      <div className="min-h-[calc(100vh-56px)] bg-gradient-to-b from-violet-700 via-purple-600 to-indigo-700 px-4 py-8 text-white">
-        <div className="mx-auto w-full max-w-lg space-y-5">
+      <div className="relative min-h-[calc(100vh-56px)] overflow-hidden bg-[#08091A] px-4 py-8 text-[#F0F0FF]">
+        <div
+          aria-hidden
+          className="absolute rounded-full pointer-events-none blur-[80px] bg-[rgba(99,102,241,0.12)]"
+          style={{ width: 400, height: 250, top: -60, left: "40%", transform: "translateX(-50%)" }}
+        />
+        <div className="relative mx-auto w-full max-w-lg space-y-5">
           {/* ヘッダー */}
           <div className="flex items-center justify-between">
             <button
               type="button"
               onClick={() => setPhase("setup")}
-              className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1.5 text-sm font-medium ring-1 ring-white/25 hover:bg-white/15"
+              className="inline-flex items-center gap-2 rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-3 py-1.5 text-sm font-medium text-[#BCC0E8] hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF]"
             >
               <span aria-hidden="true">←</span>
               設定に戻る
             </button>
-            <div className="text-sm font-semibold text-white/80">
+            <div className="font-mono text-sm font-semibold text-[#5C6199]">
               {index + 1} / {questions.length}
             </div>
           </div>
 
           {/* プログレスバー */}
-          <div className="h-2 w-full overflow-hidden rounded-full bg-white/20">
+          <div className="h-1 w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
             <div
-              className="h-full rounded-full bg-white/70 transition-all duration-300"
-              style={{ width: `${progress}%` }}
+              className="h-full rounded-full transition-all duration-300"
+              style={{
+                width: `${progress}%`,
+                background: "linear-gradient(90deg, #6366f1, #3b82f6)",
+              }}
             />
           </div>
 
           {/* 問題カード */}
-          <Card className="border-white/20 bg-white/10 backdrop-blur-md">
-            <div className="space-y-4 p-2">
+          <div className="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] p-5 backdrop-blur-xl shadow-[0_8px_32px_rgba(0,0,0,0.4)]">
+            <div className="space-y-4">
               <div className="flex items-center justify-between">
-                <div className="text-xs font-semibold text-white/55">
+                <div className="font-mono text-xs text-[#5C6199]">
                   {q.level_label_ja} · {q.question_type_label_ja}
                 </div>
                 <button
                   type="button"
                   onClick={() => speakKorean(buildSpeakText(q, isAnswered))}
                   disabled={!isSpeechSupported()}
-                  className="inline-flex items-center gap-1 rounded-full bg-white/10 px-2.5 py-1 text-xs font-medium text-white/80 ring-1 ring-white/20 hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-40"
+                  className="inline-flex items-center gap-1 rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-2.5 py-1 text-xs font-medium text-[#BCC0E8] hover:bg-[rgba(255,255,255,0.1)] disabled:cursor-not-allowed disabled:opacity-40"
                   aria-label="韓国語を音声で聞く"
                 >
                   <PlayGlyph className="h-[0.9rem] w-[0.9rem] shrink-0" />
                   <span>音声</span>
                 </button>
               </div>
-              <div className="text-xl font-bold leading-relaxed text-white sm:text-2xl">
+              <div className="text-xl font-bold leading-relaxed text-[#F0F0FF] sm:text-2xl">
                 {q.question_type === "grammar"
                   ? renderGrammarQuestionText(q.question_text)
                   : q.question_text}
               </div>
               {isAnswered && q.question_text_ja ? (
                 <div
-                  className="rounded-lg bg-white/10 px-3 py-2 text-sm text-white/80"
+                  className="rounded-lg border border-[rgba(255,255,255,0.06)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-sm text-[#9499C4]"
                   role="note"
                   aria-label="日本語訳"
                 >
                   {q.question_text_ja}
                 </div>
               ) : null}
-              <p className="text-sm text-white/60">
+              <p className="text-sm text-[#5C6199]">
                 {q.question_type === "grammar"
                   ? "（　）に入る最も適切なものを選んでください。"
                   : "무엇에 대한 내용입니까？　何についての内容ですか？"}
               </p>
             </div>
-          </Card>
+          </div>
 
           {/* 選択肢 */}
           <div className="grid grid-cols-2 gap-3">
@@ -356,18 +362,28 @@ export default function TopikPracticePage() {
               const isSelected = selectedOption === opt.option_number;
               const isThisCorrect = opt.option_number === q.correct_option_number;
 
-              let btnClass =
-                "relative w-full rounded-xl border px-4 py-3 text-base font-semibold transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-white/70";
+              let bg = "rgba(255,255,255,0.05)";
+              let border = "rgba(255,255,255,0.08)";
+              let color = "#BCC0E8";
 
-              if (!isAnswered) {
-                btnClass +=
-                  " border-white/25 bg-white/10 text-white hover:bg-white/20 hover:border-white/40 ring-1 ring-white/10";
-              } else if (isThisCorrect) {
-                btnClass += " border-emerald-300/60 bg-emerald-500/30 text-emerald-100 ring-1 ring-emerald-300/40";
-              } else if (isSelected && !isThisCorrect) {
-                btnClass += " border-red-300/60 bg-red-500/30 text-red-100 ring-1 ring-red-300/40";
-              } else {
-                btnClass += " border-white/10 bg-white/5 text-white/50";
+              if (isAnswered) {
+                if (isThisCorrect) {
+                  bg = "rgba(16,185,129,0.12)";
+                  border = "rgba(16,185,129,0.35)";
+                  color = "#34d399";
+                } else if (isSelected && !isThisCorrect) {
+                  bg = "rgba(244,63,94,0.1)";
+                  border = "rgba(244,63,94,0.3)";
+                  color = "#fb7185";
+                } else {
+                  bg = "rgba(255,255,255,0.02)";
+                  border = "rgba(255,255,255,0.05)";
+                  color = "#5C6199";
+                }
+              } else if (isSelected) {
+                bg = "rgba(99,102,241,0.12)";
+                border = "rgba(99,102,241,0.4)";
+                color = "#818cf8";
               }
 
               return (
@@ -376,22 +392,19 @@ export default function TopikPracticePage() {
                   type="button"
                   disabled={isAnswered}
                   onClick={() => handleAnswer(opt.option_number)}
-                  className={btnClass}
+                  className="relative w-full rounded-xl border px-4 py-3 text-base font-semibold transition-all duration-150 focus:outline-none focus-visible:ring-2 focus-visible:ring-[rgba(99,102,241,0.7)] backdrop-blur-xl"
+                  style={{ background: bg, borderColor: border, color }}
                 >
-                  <span className="mr-1.5 text-xs font-bold opacity-60">{opt.option_number}.</span>
+                  <span className="font-mono mr-1.5 text-xs font-bold opacity-60">{opt.option_number}.</span>
                   {opt.text}
                   {isAnswered && opt.text_ja ? (
                     <span className="ml-1.5 text-xs font-normal opacity-70">（{opt.text_ja}）</span>
                   ) : null}
                   {isAnswered && isThisCorrect && (
-                    <span className="ml-1.5 text-emerald-300" aria-hidden="true">
-                      ✓
-                    </span>
+                    <span className="ml-1.5 text-[#34d399]" aria-hidden="true">✓</span>
                   )}
                   {isAnswered && isSelected && !isThisCorrect && (
-                    <span className="ml-1.5 text-red-300" aria-hidden="true">
-                      ✗
-                    </span>
+                    <span className="ml-1.5 text-[#fb7185]" aria-hidden="true">✗</span>
                   )}
                 </button>
               );
@@ -402,16 +415,18 @@ export default function TopikPracticePage() {
           {isAnswered ? (
             <div
               className={[
-                "rounded-xl border px-4 py-3 text-sm leading-relaxed",
+                "rounded-xl border px-4 py-3 text-sm leading-relaxed backdrop-blur-xl",
                 isCorrect
-                  ? "border-emerald-300/40 bg-emerald-900/40 text-emerald-100"
-                  : "border-red-300/40 bg-red-900/40 text-red-100",
+                  ? "border-[rgba(16,185,129,0.3)] bg-[rgba(16,185,129,0.08)] text-[#34d399]"
+                  : "border-[rgba(244,63,94,0.3)] bg-[rgba(244,63,94,0.08)] text-[#fb7185]",
               ].join(" ")}
             >
               <p className="font-bold">
-                {isCorrect ? "✓ 正解！ 정답!" : `✗ 不正解。正解は「${q.options.find((o) => o.option_number === q.correct_option_number)?.text}」です。`}
+                {isCorrect
+                  ? "✓ 正解！ 정답!"
+                  : `✗ 不正解。正解は「${q.options.find((o) => o.option_number === q.correct_option_number)?.text}」です。`}
               </p>
-              {q.explanation_ja ? <p className="mt-1.5 text-white/80">{q.explanation_ja}</p> : null}
+              {q.explanation_ja ? <p className="mt-1.5 text-[#BCC0E8]">{q.explanation_ja}</p> : null}
             </div>
           ) : null}
 
@@ -433,14 +448,29 @@ export default function TopikPracticePage() {
   const scorePercent = Math.round((correctCount / results.length) * 100);
 
   return (
-    <div className="min-h-[calc(100vh-56px)] bg-gradient-to-b from-violet-700 via-purple-600 to-indigo-700 px-4 py-8 text-white">
-      <div className="mx-auto w-full max-w-lg space-y-6">
+    <div className="relative min-h-[calc(100vh-56px)] overflow-hidden bg-[#08091A] px-4 py-8 text-[#F0F0FF]">
+      <div
+        aria-hidden
+        className="absolute rounded-full pointer-events-none blur-[80px] bg-[rgba(99,102,241,0.12)]"
+        style={{ width: 500, height: 300, top: -80, left: "50%", transform: "translateX(-50%)" }}
+      />
+      <div className="relative mx-auto w-full max-w-lg space-y-6">
         {/* スコア */}
-        <div className="rounded-2xl border border-white/20 bg-white/10 px-6 py-8 text-center backdrop-blur-md ring-1 ring-white/10">
-          <div className="text-lg font-semibold text-white/70">結果 결과</div>
-          <div className="mt-2 text-6xl font-extrabold text-white drop-shadow-md">{scorePercent}%</div>
-          <div className="mt-2 text-base text-white/80">
-            {results.length} 問中 <span className="font-bold text-emerald-300">{correctCount} 問</span> 正解
+        <div
+          className="rounded-2xl border border-[rgba(99,102,241,0.25)] p-8 text-center backdrop-blur-xl shadow-[0_0_24px_rgba(99,102,241,0.15),0_8px_32px_rgba(0,0,0,0.4)]"
+          style={{ background: "linear-gradient(135deg, rgba(99,102,241,0.1), rgba(59,130,246,0.06))" }}
+        >
+          <div className="text-lg font-semibold text-[#9499C4]">結果 결과</div>
+          <div
+            className="mt-2 text-6xl font-extrabold"
+            style={{ background: "linear-gradient(135deg,#6366f1,#3b82f6)", WebkitBackgroundClip: "text", WebkitTextFillColor: "transparent", backgroundClip: "text" }}
+          >
+            {scorePercent}%
+          </div>
+          <div className="mt-2 text-base text-[#BCC0E8]">
+            {results.length} 問中{" "}
+            <span className="font-bold text-[#34d399]">{correctCount} 問</span>{" "}
+            正解
           </div>
         </div>
 
@@ -460,8 +490,8 @@ export default function TopikPracticePage() {
         <Section
           title="問題別結果"
           subtitle="문제별 결과"
-          headerClassName="rounded-2xl bg-white/10 px-4 py-3 ring-1 ring-white/10 backdrop-blur"
-          titleClassName="text-white drop-shadow-sm"
+          headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
+          titleClassName="text-[#F0F0FF]"
         >
           <div className="space-y-3">
             {results.map((r, i) => {
@@ -472,14 +502,14 @@ export default function TopikPracticePage() {
                 <div
                   key={r.question.id}
                   className={[
-                    "rounded-xl border px-4 py-3 text-sm",
+                    "rounded-xl border px-4 py-3 text-sm backdrop-blur-xl",
                     r.correct
-                      ? "border-emerald-300/30 bg-emerald-900/30 text-white"
-                      : "border-red-300/30 bg-red-900/30 text-white",
+                      ? "border-[rgba(16,185,129,0.25)] bg-[rgba(16,185,129,0.06)] text-[#F0F0FF]"
+                      : "border-[rgba(244,63,94,0.25)] bg-[rgba(244,63,94,0.06)] text-[#F0F0FF]",
                   ].join(" ")}
                 >
                   <div className="flex items-start justify-between gap-2">
-                    <span className="font-bold text-white/60">Q{i + 1}.</span>
+                    <span className="font-mono font-bold text-[#5C6199]">Q{i + 1}.</span>
                     <div className="flex-1">
                       <div className="flex items-center gap-2">
                         <span className="font-medium leading-relaxed">{r.question.question_text}</span>
@@ -487,31 +517,31 @@ export default function TopikPracticePage() {
                           type="button"
                           onClick={() => speakKorean(buildSpeakText(r.question, true))}
                           disabled={!isSpeechSupported()}
-                          className="shrink-0 inline-flex items-center justify-center rounded-full bg-white/10 px-1.5 py-1 text-white/70 ring-1 ring-white/20 hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-40"
+                          className="shrink-0 inline-flex items-center justify-center rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-1.5 py-1 text-[#BCC0E8] hover:bg-[rgba(255,255,255,0.1)] disabled:cursor-not-allowed disabled:opacity-40"
                           aria-label="韓国語を音声で聞く"
                         >
                           <PlayGlyph className="h-[0.9rem] w-[0.9rem] shrink-0" />
                         </button>
                       </div>
                       {r.question.question_text_ja ? (
-                        <div className="mt-0.5 text-xs text-white/55" role="note" aria-label="日本語訳">
+                        <div className="mt-0.5 text-xs text-[#5C6199]" role="note" aria-label="日本語訳">
                           {r.question.question_text_ja}
                         </div>
                       ) : null}
                     </div>
                     <span
-                      className={["font-bold", r.correct ? "text-emerald-300" : "text-red-300"].join(" ")}
+                      className={["font-bold", r.correct ? "text-[#34d399]" : "text-[#fb7185]"].join(" ")}
                       aria-label={r.correct ? "正解" : "不正解"}
                     >
                       {r.correct ? "✓" : "✗"}
                     </span>
                   </div>
                   {!r.correct ? (
-                    <p className="mt-1 text-white/70">
+                    <p className="mt-1 text-[#9499C4]">
                       正解:{" "}
-                      <span className="font-semibold text-emerald-200">{correctOpt?.text}</span>
+                      <span className="font-semibold text-[#34d399]">{correctOpt?.text}</span>
                       {correctOpt?.text_ja ? (
-                        <span className="ml-1 text-emerald-200/70">（{correctOpt.text_ja}）</span>
+                        <span className="ml-1 text-[rgba(52,211,153,0.7)]">（{correctOpt.text_ja}）</span>
                       ) : null}
                     </p>
                   ) : null}
@@ -525,13 +555,13 @@ export default function TopikPracticePage() {
           <button
             type="button"
             onClick={() => setPhase("setup")}
-            className="flex-1 rounded-xl border border-white/30 bg-white/10 px-4 py-2.5 text-sm font-semibold text-white hover:bg-white/20"
+            className="flex-1 rounded-xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-2.5 text-sm font-semibold text-[#BCC0E8] hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF]"
           >
             ← 設定に戻る
           </button>
           <Link
             href="/quiz"
-            className="flex-1 rounded-xl border border-white/30 bg-white/10 px-4 py-2.5 text-center text-sm font-semibold text-white hover:bg-white/20"
+            className="flex-1 rounded-xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-2.5 text-center text-sm font-semibold text-[#BCC0E8] hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF]"
           >
             語彙クイズへ →
           </Link>

--- a/frontend/src/app/vocabularies/[id]/page.tsx
+++ b/frontend/src/app/vocabularies/[id]/page.tsx
@@ -115,20 +115,25 @@ export default function VocabularyDetailPage() {
 
   if (state.status === "loading") {
     return (
-      <div className="flex flex-1 items-center justify-center bg-zinc-50 px-4 py-10">
-        <div className="text-sm text-zinc-600">読み込み中...</div>
+      <div className="flex flex-1 items-center justify-center bg-[#08091A] px-4 py-10">
+        <div className="text-sm text-[#9499C4]">読み込み中...</div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-[calc(100vh-56px)] bg-gradient-to-b from-sky-600 via-teal-500 to-cyan-700 px-4 py-8 text-white">
-      <div className="mx-auto w-full max-w-3xl space-y-6">
+    <div className="relative min-h-[calc(100vh-56px)] overflow-hidden bg-[#08091A] px-4 py-8 text-[#F0F0FF]">
+      <div
+        aria-hidden
+        className="absolute rounded-full pointer-events-none blur-[80px] bg-[rgba(99,102,241,0.10)]"
+        style={{ width: 500, height: 350, top: -80, left: "50%", transform: "translateX(-50%)" }}
+      />
+      <div className="relative mx-auto w-full max-w-3xl space-y-6">
         <div className="flex items-center justify-between">
           <button
             type="button"
             onClick={() => router.back()}
-            className="inline-flex items-center gap-2 rounded-full bg-white/10 px-3 py-1.5 text-sm font-medium text-white ring-1 ring-white/25 hover:bg-white/15 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-transparent"
+            className="inline-flex items-center gap-2 rounded-full border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-3 py-1.5 text-sm font-medium text-[#BCC0E8] backdrop-blur-xl hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#6366f1] focus-visible:ring-offset-2 focus-visible:ring-offset-[#08091A]"
           >
             <span aria-hidden="true">←</span>
             一覧に戻る
@@ -139,11 +144,9 @@ export default function VocabularyDetailPage() {
               disabled
               aria-disabled="true"
               title="会員登録が必要です"
-              className="inline-flex cursor-not-allowed items-center gap-1.5 rounded-full bg-white/10 px-3 py-1.5 text-sm font-medium text-white/60 ring-1 ring-white/20"
+              className="inline-flex cursor-not-allowed items-center gap-1.5 rounded-full border border-[rgba(255,255,255,0.06)] bg-[rgba(255,255,255,0.03)] px-3 py-1.5 text-sm font-medium text-[#5C6199]"
             >
-              <span aria-hidden="true" className="text-base leading-none">
-                🏷️
-              </span>
+              <span aria-hidden="true" className="text-base leading-none">🏷️</span>
               ブックマーク
             </button>
           ) : state.status === "authed" && bookmarked !== null ? (
@@ -152,10 +155,10 @@ export default function VocabularyDetailPage() {
               disabled={bookmarkBusy || loading}
               onClick={handleBookmarkToggle}
               className={[
-                "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium ring-1 transition-colors",
+                "inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 text-sm font-medium border transition-colors",
                 bookmarked
-                  ? "bg-white/20 text-white ring-white/30 hover:bg-white/30"
-                  : "bg-white/10 text-white/80 ring-white/25 hover:bg-white/15",
+                  ? "bg-[rgba(99,102,241,0.15)] text-[#818cf8] border-[rgba(99,102,241,0.3)] hover:bg-[rgba(99,102,241,0.2)]"
+                  : "bg-[rgba(255,255,255,0.05)] text-[#BCC0E8] border-[rgba(255,255,255,0.08)] hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF]",
                 bookmarkBusy ? "opacity-60" : "",
               ].join(" ")}
             >
@@ -172,19 +175,22 @@ export default function VocabularyDetailPage() {
         </div>
 
         {state.status === "guest" ? (
-          <Card className="border-amber-300/30 bg-amber-500/15 text-white ring-1 ring-amber-200/25 backdrop-blur">
-            <p className="text-sm font-semibold text-amber-50">ブックマークは会員の方のみご利用いただけます</p>
-            <p className="mt-2 text-sm leading-relaxed text-white/85">
+          <Card className="border-[rgba(99,102,241,0.25)] bg-[rgba(99,102,241,0.08)] text-[#F0F0FF] backdrop-blur-xl">
+            <p className="text-sm font-semibold text-[#818cf8]">ブックマークは会員の方のみご利用いただけます</p>
+            <p className="mt-2 text-sm leading-relaxed text-[#BCC0E8]">
               語彙をブックマークに保存するには、
-              <strong className="text-white">無料の会員登録</strong>
+              <strong className="text-[#F0F0FF]">無料の会員登録</strong>
               が必要です。アカウントをお持ちの方はログインしてください。
             </p>
             <p className="mt-3 flex flex-wrap gap-x-3 gap-y-2 text-sm font-semibold">
-              <Link className="rounded-md bg-white px-3 py-1.5 text-zinc-900 hover:bg-white/90" href="/register">
+              <Link
+                className="rounded-xl bg-[linear-gradient(135deg,#6366f1,#3b82f6)] px-3 py-1.5 text-white hover:opacity-90"
+                href="/register"
+              >
                 無料で会員登録
               </Link>
               <Link
-                className="rounded-md border border-white/40 px-3 py-1.5 text-white hover:bg-white/10"
+                className="rounded-xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-3 py-1.5 text-[#BCC0E8] hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF]"
                 href="/login"
               >
                 ログイン
@@ -193,7 +199,7 @@ export default function VocabularyDetailPage() {
           </Card>
         ) : null}
 
-        <Card className="border-white/10 bg-white/10 text-white backdrop-blur">
+        <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
           <div className="flex flex-col gap-4">
             <div className="flex items-start justify-between gap-4">
               <div className="min-w-0">
@@ -204,14 +210,14 @@ export default function VocabularyDetailPage() {
                   </>
                 ) : (
                   <>
-                    <h1 className="truncate text-4xl font-extrabold tracking-tight text-white drop-shadow-sm sm:text-5xl">
+                    <h1 className="truncate text-4xl font-extrabold tracking-tight text-[#F0F0FF] sm:text-5xl">
                       {item?.term ?? "語彙"}
                     </h1>
-                    <p className="mt-2 text-lg font-semibold text-white/90">{item?.meaning_ja ?? ""}</p>
+                    <p className="mt-2 text-lg font-semibold text-[#BCC0E8]">{item?.meaning_ja ?? ""}</p>
                   </>
                 )}
               </div>
-              <div className="flex shrink-0 flex-col items-end gap-2 text-right text-xs text-white/80">
+              <div className="flex shrink-0 flex-col items-end gap-2 text-right text-xs text-[#9499C4]">
                 <div>
                   <div className="font-semibold">{item?.level_label_ja ?? ""}</div>
                   <div className="mt-1">{item?.pos_label_ja ?? ""}</div>
@@ -249,18 +255,18 @@ export default function VocabularyDetailPage() {
               ) : null}
             </div>
 
-            {error ? <div className="text-sm font-medium text-red-200">{error}</div> : null}
+            {error ? <div className="text-sm font-medium text-[#fb7185]">{error}</div> : null}
           </div>
         </Card>
 
         <Section
           title="例文"
           subtitle="예문"
-          headerClassName="rounded-2xl bg-white/10 px-4 py-3 ring-1 ring-white/10 backdrop-blur"
-          titleClassName="text-white drop-shadow-sm"
-          descriptionClassName="text-white/80"
+          headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
+          titleClassName="text-[#F0F0FF]"
+          descriptionClassName="text-[#9499C4]"
         >
-          <Card className="border-white/10 bg-white/10 text-white backdrop-blur">
+          <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
             <div className="grid gap-4 text-base leading-relaxed">
               {item?.example_sentence ? (
                 <div className="flex flex-wrap items-start justify-between gap-3">
@@ -268,10 +274,10 @@ export default function VocabularyDetailPage() {
                     <div className="shrink-0 self-start text-lg leading-none" aria-hidden="true">
                       🇰🇷
                     </div>
-                    <div className="min-w-0 text-white/90">
+                    <div className="min-w-0 text-[#BCC0E8]">
                       <HighlightedExampleText
                         text={item.example_sentence}
-                        markClassName="font-semibold text-white underline decoration-amber-200/90 decoration-2 underline-offset-[0.22em]"
+                        markClassName="font-semibold text-[#818cf8] underline decoration-[rgba(99,102,241,0.5)] decoration-2 underline-offset-[0.22em]"
                       />
                     </div>
                   </div>
@@ -284,7 +290,7 @@ export default function VocabularyDetailPage() {
                   ) : null}
                 </div>
               ) : (
-                <div className="text-base text-white/70">例文は未登録です。</div>
+                <div className="text-base text-[#5C6199]">例文は未登録です。</div>
               )}
 
               {item?.example_translation_ja ? (
@@ -292,10 +298,10 @@ export default function VocabularyDetailPage() {
                   <div className="shrink-0 self-start text-lg leading-none" aria-hidden="true">
                     🇯🇵
                   </div>
-                  <div className="text-white/80">
+                  <div className="text-[#9499C4]">
                     <HighlightedExampleText
                       text={item.example_translation_ja}
-                      markClassName="font-semibold text-white/95 underline decoration-teal-200/85 decoration-2 underline-offset-[0.22em]"
+                      markClassName="font-semibold text-[#BCC0E8] underline decoration-[rgba(99,102,241,0.4)] decoration-2 underline-offset-[0.22em]"
                     />
                   </div>
                 </div>
@@ -307,4 +313,3 @@ export default function VocabularyDetailPage() {
     </div>
   );
 }
-

--- a/frontend/src/app/vocabularies/page.tsx
+++ b/frontend/src/app/vocabularies/page.tsx
@@ -64,9 +64,9 @@ export default function VocabulariesPage() {
         <div
           role="status"
           aria-live="polite"
-          className="flex flex-1 items-center justify-center bg-zinc-50 px-4 py-10"
+          className="flex flex-1 items-center justify-center bg-[#08091A] px-4 py-10"
         >
-          <div className="text-sm text-zinc-600">読み込み中...</div>
+          <div className="text-sm text-[#9499C4]">読み込み中...</div>
         </div>
       }
     >
@@ -170,21 +170,26 @@ function VocabulariesPageInner() {
 
   if (state.status === "loading") {
     return (
-      <div className="flex flex-1 items-center justify-center bg-zinc-50 px-4 py-10">
-        <div className="text-sm text-zinc-600">読み込み中...</div>
+      <div className="flex flex-1 items-center justify-center bg-[#08091A] px-4 py-10">
+        <div className="text-sm text-[#9499C4]">読み込み中...</div>
       </div>
     );
   }
 
   return (
-    <div className="min-h-[calc(100vh-56px)] bg-gradient-to-b from-sky-600 via-teal-500 to-cyan-700 px-4 py-8 text-white">
-      <div className="mx-auto w-full max-w-5xl space-y-6">
+    <div className="relative min-h-[calc(100vh-56px)] overflow-hidden bg-[#08091A] px-4 py-8 text-[#F0F0FF]">
+      <div
+        aria-hidden
+        className="absolute rounded-full pointer-events-none blur-[80px] bg-[rgba(99,102,241,0.10)]"
+        style={{ width: 600, height: 400, top: -100, left: "50%", transform: "translateX(-50%)" }}
+      />
+      <div className="relative mx-auto w-full max-w-5xl space-y-6">
         <div className="flex flex-col gap-2">
-          <h1 className="text-3xl font-extrabold tracking-tight text-white drop-shadow-sm sm:text-4xl">
-            語彙
-            <span className="ml-2 align-baseline text-lg font-semibold text-white/85">단어</span>
+          <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
+            <span className="bg-[linear-gradient(135deg,#6366f1,#3b82f6)] bg-clip-text text-transparent">語彙</span>
+            <span className="ml-2 align-baseline text-lg font-semibold text-[#9499C4]">단어</span>
           </h1>
-          <p className="text-sm text-white/80">
+          <p className="text-sm text-[#BCC0E8]">
             目的の語を、レベルや品詞からさっと探して意味や例文を確認できます。
           </p>
         </div>
@@ -193,12 +198,12 @@ function VocabulariesPageInner() {
           title="絞り込み"
           subtitle="필터"
           description="タップで絞り込み。もう一度タップで解除できます。"
-          headerClassName="rounded-2xl bg-white/10 px-4 py-3 ring-1 ring-white/10 backdrop-blur"
-          titleClassName="text-white drop-shadow-sm"
-          descriptionClassName="text-white/80"
+          headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
+          titleClassName="text-[#F0F0FF]"
+          descriptionClassName="text-[#9499C4]"
           right={
             <Button
-              variant="secondary"
+              variant="ghost"
               type="button"
               onClick={() => {
                 setQInput("");
@@ -209,7 +214,7 @@ function VocabulariesPageInner() {
             </Button>
           }
         >
-          <Card className="border-white/10 bg-white/10 text-white backdrop-blur">
+          <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
             <div className="space-y-4">
               <div>
                 <Input
@@ -224,8 +229,8 @@ function VocabulariesPageInner() {
               </div>
 
               <div>
-                <div className="text-sm font-semibold text-white">
-                  TOPIK <span className="ml-1 font-semibold text-white/80">토픽</span>
+                <div className="text-sm font-semibold text-[#F0F0FF]">
+                  TOPIK <span className="ml-1 font-semibold text-[#9499C4]">토픽</span>
                 </div>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {LEVEL_OPTIONS.map((o) => (
@@ -244,8 +249,8 @@ function VocabulariesPageInner() {
               </div>
 
               <div>
-                <div className="text-sm font-semibold text-white">
-                  種別 <span className="ml-1 font-semibold text-white/80">유형</span>
+                <div className="text-sm font-semibold text-[#F0F0FF]">
+                  種別 <span className="ml-1 font-semibold text-[#9499C4]">유형</span>
                 </div>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {ENTRY_TYPE_OPTIONS.map((o) => (
@@ -266,8 +271,8 @@ function VocabulariesPageInner() {
               </div>
 
               <div>
-                <div className="text-sm font-semibold text-white">
-                  品詞 <span className="ml-1 font-semibold text-white/80">품사</span>
+                <div className="text-sm font-semibold text-[#F0F0FF]">
+                  品詞 <span className="ml-1 font-semibold text-[#9499C4]">품사</span>
                 </div>
                 <div className="mt-2 flex flex-wrap gap-2">
                   {POS_OPTIONS.map((o) => (
@@ -292,15 +297,15 @@ function VocabulariesPageInner() {
           title="語彙一覧"
           subtitle="단어 목록"
           description={loading ? "読み込み中..." : `件数: ${items?.length ?? 0}`}
-          right={error ? <div className="text-sm font-medium text-red-200">{error}</div> : null}
-          headerClassName="rounded-2xl bg-white/10 px-4 py-3 ring-1 ring-white/10 backdrop-blur"
-          titleClassName="text-white drop-shadow-sm"
-          descriptionClassName="text-white/80"
+          right={error ? <div className="text-sm font-medium text-[#fb7185]">{error}</div> : null}
+          headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
+          titleClassName="text-[#F0F0FF]"
+          descriptionClassName="text-[#9499C4]"
         >
           {loading ? (
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
               {Array.from({ length: 9 }).map((_, i) => (
-                <Card key={i} className="border-white/10 bg-white/10 p-5 text-white backdrop-blur">
+                <Card key={i} className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] p-5 backdrop-blur-xl">
                   <Skeleton className="h-6 w-2/3" />
                   <Skeleton className="mt-3 h-4 w-5/6" />
                   <div className="mt-4 flex gap-2">
@@ -315,9 +320,9 @@ function VocabulariesPageInner() {
           ) : null}
 
           {!loading && items && items.length === 0 ? (
-            <Card className="border-white/10 bg-white/10 text-center text-white backdrop-blur">
-              <div className="text-sm font-semibold text-white">該当する語彙がありません</div>
-              <div className="mt-1 text-sm text-white/80">絞り込みをリセットしてみてください。</div>
+            <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-center text-[#F0F0FF] backdrop-blur-xl">
+              <div className="text-sm font-semibold text-[#F0F0FF]">該当する語彙がありません</div>
+              <div className="mt-1 text-sm text-[#9499C4]">絞り込みをリセットしてみてください。</div>
             </Card>
           ) : null}
         </Section>

--- a/frontend/src/components/nav/AppHeader.tsx
+++ b/frontend/src/components/nav/AppHeader.tsx
@@ -28,8 +28,8 @@ function NavLink({
   const cls =
     tone === "dark"
       ? isActive
-        ? `${base} bg-white text-zinc-900`
-        : `${base} text-white/90 hover:bg-white/10`
+        ? `${base} bg-white/10 text-[#818cf8] border border-[rgba(99,102,241,0.3)]`
+        : `${base} text-[#BCC0E8] hover:bg-white/8 hover:text-[#F0F0FF]`
       : isActive
         ? `${base} bg-zinc-900 text-white`
         : `${base} text-zinc-700 hover:bg-zinc-100`;
@@ -63,8 +63,8 @@ function MobileNavLink({
   const cls =
     tone === "dark"
       ? isActive
-        ? `${base} bg-white text-zinc-900`
-        : `${base} text-white/90 hover:bg-white/10`
+        ? `${base} bg-[rgba(99,102,241,0.15)] text-[#818cf8]`
+        : `${base} text-[#9499C4] hover:bg-white/8 hover:text-[#BCC0E8]`
       : isActive
         ? `${base} bg-zinc-900 text-white`
         : `${base} text-zinc-700 hover:bg-zinc-100`;
@@ -102,9 +102,9 @@ export function AppHeader() {
         isLearnerGlass
           ? [
               "sticky top-0 z-20",
-              "border-b border-white/10",
-              "bg-gradient-to-r from-sky-700/70 via-teal-600/60 to-cyan-700/70",
-              "backdrop-blur",
+              "border-b border-white/[0.06]",
+              "bg-[rgba(8,9,26,0.85)]",
+              "backdrop-blur-xl",
             ].join(" ")
           : "border-b border-zinc-200 bg-white"
       }
@@ -115,11 +115,11 @@ export function AppHeader() {
             href="/"
             className={
               isLearnerGlass
-                ? "text-sm font-semibold text-white drop-shadow-sm"
+                ? "text-sm font-bold bg-[linear-gradient(135deg,#6366f1,#3b82f6)] bg-clip-text text-transparent"
                 : "text-sm font-semibold text-zinc-900"
             }
           >
-            Korean TOPIK App
+            Korean TOPIK
           </Link>
           <nav className="hidden items-center gap-1 sm:flex">
             <NavLink href="/vocabularies" label="語彙" tone={tone} />
@@ -136,13 +136,13 @@ export function AppHeader() {
               <div
                 className={
                   isLearnerGlass
-                    ? "hidden text-sm text-white/80 sm:block"
+                    ? "hidden text-sm text-[#9499C4] sm:block"
                     : "hidden text-sm text-zinc-600 sm:block"
                 }
               >
                 {state.user.nickname ?? state.user.name}
               </div>
-              <Button variant="secondary" type="button" onClick={() => logout()}>
+              <Button variant={isLearnerGlass ? "ghost" : "secondary"} type="button" onClick={() => logout()}>
                 ログアウト
               </Button>
             </>
@@ -151,7 +151,7 @@ export function AppHeader() {
               <Link
                 className={
                   isLearnerGlass
-                    ? "rounded-md px-3 py-2 text-sm font-medium text-white/90 hover:bg-white/10"
+                    ? "rounded-md px-3 py-2 text-sm font-medium text-[#BCC0E8] hover:bg-white/8 hover:text-[#F0F0FF]"
                     : "rounded-md px-3 py-2 text-sm font-medium text-zinc-700 hover:bg-zinc-100"
                 }
                 href="/login"
@@ -161,7 +161,7 @@ export function AppHeader() {
               <Link
                 className={
                   isLearnerGlass
-                    ? "rounded-md bg-white px-3 py-2 text-sm font-semibold text-zinc-900 hover:bg-white/90"
+                    ? "rounded-md bg-[linear-gradient(135deg,#6366f1,#3b82f6)] px-3 py-2 text-sm font-semibold text-white shadow-[0_4px_16px_rgba(99,102,241,0.3)] hover:opacity-90"
                     : "rounded-md bg-zinc-900 px-3 py-2 text-sm font-medium text-white hover:bg-zinc-800"
                 }
                 href="/register"
@@ -231,4 +231,3 @@ export function AppHeader() {
     </header>
   );
 }
-

--- a/frontend/src/components/ui/Button.tsx
+++ b/frontend/src/components/ui/Button.tsx
@@ -1,16 +1,23 @@
 import React from "react";
 
 type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
-  variant?: "primary" | "secondary";
+  variant?: "primary" | "secondary" | "ghost" | "danger";
 };
 
 export function Button({ className = "", variant = "primary", ...props }: Props) {
   const base =
-    "inline-flex items-center justify-center rounded-md px-4 py-2 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed";
-  const styles =
-    variant === "primary"
-      ? "bg-zinc-900 text-white hover:bg-zinc-800"
-      : "bg-white text-zinc-900 border border-zinc-200 hover:bg-zinc-50";
-  return <button className={`${base} ${styles} ${className}`} {...props} />;
-}
+    "inline-flex items-center justify-center rounded-xl px-4 py-2.5 text-sm font-semibold transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed";
 
+  const styles: Record<NonNullable<Props["variant"]>, string> = {
+    primary:
+      "bg-[linear-gradient(135deg,#6366f1,#3b82f6)] text-white shadow-[0_4px_16px_rgba(99,102,241,0.3)] hover:opacity-90 hover:shadow-[0_4px_20px_rgba(99,102,241,0.4)]",
+    secondary:
+      "bg-white text-zinc-900 border border-zinc-200 hover:bg-zinc-50",
+    ghost:
+      "bg-[rgba(255,255,255,0.05)] text-[#BCC0E8] border border-[rgba(255,255,255,0.08)] hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF]",
+    danger:
+      "bg-[rgba(244,63,94,0.12)] text-[#fb7185] border border-[rgba(244,63,94,0.25)] hover:bg-[rgba(244,63,94,0.2)]",
+  };
+
+  return <button className={`${base} ${styles[variant]} ${className}`} {...props} />;
+}

--- a/frontend/src/components/ui/Card.tsx
+++ b/frontend/src/components/ui/Card.tsx
@@ -13,7 +13,7 @@ export function Card({
 }) {
   const base = hasBackgroundUtility(className)
     ? "rounded-xl border p-6 shadow-sm"
-    : "rounded-xl border border-zinc-200 bg-white p-6 shadow-sm";
+    : "rounded-xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] p-6 backdrop-blur-xl shadow-[0_8px_32px_rgba(0,0,0,0.4)]";
 
   return (
     <div className={`${base} ${className}`}>
@@ -21,4 +21,3 @@ export function Card({
     </div>
   );
 }
-

--- a/frontend/src/components/ui/Chip.tsx
+++ b/frontend/src/components/ui/Chip.tsx
@@ -6,10 +6,9 @@ type Props = React.ButtonHTMLAttributes<HTMLButtonElement> & {
 
 export function Chip({ className = "", selected = false, ...props }: Props) {
   const base =
-    "inline-flex items-center justify-center rounded-full px-3 py-1.5 text-sm font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ring-1 ring-inset";
+    "inline-flex items-center justify-center rounded-lg px-3.5 py-1.5 text-sm font-medium transition-all duration-150 disabled:opacity-50 disabled:cursor-not-allowed border";
   const styles = selected
-    ? "bg-white text-zinc-900 ring-white/40"
-    : "bg-white/10 text-white ring-white/25 hover:bg-white/15";
+    ? "bg-[rgba(99,102,241,0.15)] text-[#818cf8] border-[rgba(99,102,241,0.3)]"
+    : "bg-[rgba(255,255,255,0.05)] text-[#BCC0E8] border-[rgba(255,255,255,0.08)] hover:bg-[rgba(255,255,255,0.08)] hover:text-[#F0F0FF]";
   return <button className={`${base} ${styles} ${className}`} {...props} />;
 }
-

--- a/frontend/src/components/ui/Section.tsx
+++ b/frontend/src/components/ui/Section.tsx
@@ -25,7 +25,7 @@ export function Section({
     <section className={`space-y-3 ${className}`}>
       <div className={`flex items-end justify-between gap-4 ${headerClassName}`}>
         <div>
-          <h2 className={`text-lg font-semibold text-zinc-900 ${titleClassName}`}>
+          <h2 className={`text-lg font-semibold ${titleClassName || "text-zinc-900"}`}>
             {title}
             {subtitle ? (
               <span className="ml-2 align-baseline text-sm font-semibold opacity-80">
@@ -34,7 +34,7 @@ export function Section({
             ) : null}
           </h2>
           {description ? (
-            <p className={`mt-1 text-sm text-zinc-600 ${descriptionClassName}`}>{description}</p>
+            <p className={`mt-1 text-sm ${descriptionClassName || "text-zinc-600"}`}>{description}</p>
           ) : null}
         </div>
         {right ? <div className="shrink-0">{right}</div> : null}


### PR DESCRIPTION
## Summary

- `#08091A` ダークネイビー背景、indigo (`#6366f1`) → blue (`#3b82f6`) グラデーションのブランドカラーを全ページに統一
- ガラスカード（`rgba(255,255,255,0.05)` + `backdrop-blur-xl` + `1px rgba(255,255,255,0.08)` ボーダー）で統一された UI コンポーネントに刷新
- 対象ページ: ホーム、クイズ、TOPIK練習、プロフィール、語彙一覧・詳細、ブックマーク
- `Section` コンポーネントのバグ修正: `titleClassName` が Tailwind v4 のカスケード順で `text-zinc-900` に打ち消されていた問題を解消

## Changes

| ファイル | 変更内容 |
|---|---|
| `globals.css` | TOPIK カラートークン・フォント変数追加 |
| `layout.tsx` | JetBrains Mono フォント追加 |
| `AppHeader.tsx` | ダークナビゲーションガラス UI |
| `Button.tsx` | ghost/danger バリアント追加、primary をグラデーションに |
| `Card.tsx` | デフォルトをガラスカードに変更 |
| `Chip.tsx` | selected = indigo、unselected = ガラス |
| `Section.tsx` | titleClassName/descriptionClassName のデフォルト色バグ修正 |
| 全ページ tsx | ダーク glassmorphism に統一 |

## Test plan

- [ ] `/` ホームページ — ダークネイビー背景、グラデーションヒーローテキスト
- [ ] `/quiz` — ガラス設定カード、indigo チップ、グラデーションスタートボタン
- [ ] `/topik-practice` — ダーク背景、indigo 空欄ハイライト
- [ ] `/vocabularies` — ガラスフィルターカード、indigo グラデーションタイトル
- [ ] `/vocabularies/[id]` — ガラス詳細カード、indigo ブックマークボタン
- [ ] `/bookmarks` — ガラスカード、ゲスト状態のグラデーション登録ボタン
- [ ] `/me` — indigo グラデーションアバター、ガラス情報カード
- [ ] セクションヘッダーがすべて白文字で視認できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)