### PR TITLE
fix: ナビと重複するページ見出しを削除

### DIFF
--- a/frontend/src/app/bookmarks/page.tsx
+++ b/frontend/src/app/bookmarks/page.tsx
@@ -115,16 +115,6 @@ export default function BookmarksPage() {
         style={{ width: 500, height: 350, top: -80, left: "50%", transform: "translateX(-50%)" }}
       />
       <div className="relative mx-auto w-full max-w-5xl space-y-6">
-        <div className="flex flex-col gap-2">
-          <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
-            <span className="bg-[linear-gradient(135deg,#6366f1,#3b82f6)] bg-clip-text text-transparent">ブックマーク</span>
-            <span className="ml-2 align-baseline text-lg font-semibold text-[#9499C4]">
-              북마크
-            </span>
-          </h1>
-          <p className="text-sm text-[#BCC0E8]">保存した語彙を確認できます。</p>
-        </div>
-
         <Section
           title="保存済み語彙"
           subtitle="저장된 단어"

--- a/frontend/src/app/quiz/page.tsx
+++ b/frontend/src/app/quiz/page.tsx
@@ -261,16 +261,6 @@ export default function QuizPage() {
           style={{ width: 500, height: 300, top: -50, left: "50%", transform: "translateX(-50%)" }}
         />
         <div className="relative mx-auto w-full max-w-lg space-y-6">
-          <div>
-            <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
-              フラッシュカード
-              <span className="ml-2 align-baseline text-lg font-semibold text-[#9499C4]">플래시카드</span>
-            </h1>
-            <p className="mt-1 text-sm text-[#9499C4]">
-              ランダム出題。答えを見てから「わからない」「わかった」で次へ進みます。
-            </p>
-          </div>
-
           <Section
             title="設定"
             subtitle="설정"

--- a/frontend/src/app/topik-practice/page.tsx
+++ b/frontend/src/app/topik-practice/page.tsx
@@ -179,16 +179,6 @@ export default function TopikPracticePage() {
           style={{ width: 500, height: 300, top: -60, left: "50%", transform: "translateX(-50%)" }}
         />
         <div className="relative mx-auto w-full max-w-lg space-y-6">
-          <div>
-            <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
-              TOPIK 問題練習
-              <span className="ml-2 align-baseline text-lg font-semibold text-[#9499C4]">문제 연습</span>
-            </h1>
-            <p className="mt-1 text-sm text-[#9499C4]">
-              文法の空欄補充問題（TOPIK 1 の31〜37番形式）。選択肢から正解を選んでください。
-            </p>
-          </div>
-
           <Section
             title="設定"
             subtitle="설정"

--- a/frontend/src/app/vocabularies/page.tsx
+++ b/frontend/src/app/vocabularies/page.tsx
@@ -184,16 +184,6 @@ function VocabulariesPageInner() {
         style={{ width: 600, height: 400, top: -100, left: "50%", transform: "translateX(-50%)" }}
       />
       <div className="relative mx-auto w-full max-w-5xl space-y-6">
-        <div className="flex flex-col gap-2">
-          <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
-            <span className="bg-[linear-gradient(135deg,#6366f1,#3b82f6)] bg-clip-text text-transparent">語彙</span>
-            <span className="ml-2 align-baseline text-lg font-semibold text-[#9499C4]">단어</span>
-          </h1>
-          <p className="text-sm text-[#BCC0E8]">
-            目的の語を、レベルや品詞からさっと探して意味や例文を確認できます。
-          </p>
-        </div>
-
         <Section
           title="絞り込み"
           subtitle="필터"


### PR DESCRIPTION
## Summary

- 語彙一覧・ブックマーク・クイズ・TOPIK練習の各ページ先頭にあった h1 見出し＋説明文ブロックを削除
- ナビバーに既にページ名が表示されているため冗長と判断

## Test plan

- [ ] `/vocabularies` — ヘッダーのすぐ下からフィルターが始まること
- [ ] `/bookmarks` — ヘッダーのすぐ下からリストが始まること
- [ ] `/quiz` — ヘッダーのすぐ下から設定セクションが始まること
- [ ] `/topik-practice` — ヘッダーのすぐ下から問題セクションが始まること

🤖 Generated with [Claude Code](https://claude.com/claude-code)