### PR TITLE
feat: セクション見出しをカード内に統合（パターンA）

### DIFF
--- a/frontend/src/app/bookmarks/page.tsx
+++ b/frontend/src/app/bookmarks/page.tsx
@@ -5,7 +5,6 @@ import { useEffect, useState } from "react";
 
 import { useAuth } from "@/components/auth/AuthProvider";
 import { Card } from "@/components/ui/Card";
-import { Section } from "@/components/ui/Section";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { BookmarkListVirtualGrid } from "@/components/vocabulary/BookmarkListVirtualGrid";
 import {
@@ -115,15 +114,14 @@ export default function BookmarksPage() {
         style={{ width: 500, height: 350, top: -80, left: "50%", transform: "translateX(-50%)" }}
       />
       <div className="relative mx-auto w-full max-w-5xl space-y-6">
-        <Section
-          title="保存済み語彙"
-          subtitle="저장된 단어"
-          description={loading ? "読み込み中..." : `件数: ${items?.length ?? 0}`}
-          right={error ? <div className="text-sm font-medium text-[#fb7185]">{error}</div> : null}
-          headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
-          titleClassName="text-[#F0F0FF]"
-          descriptionClassName="text-[#9499C4]"
-        >
+        <div className="space-y-3">
+          <div className="flex items-center justify-between px-1">
+            <h2 className="text-sm font-semibold text-[#F0F0FF]">保存済み語彙 <span className="ml-1.5 text-xs font-medium text-[#9499C4]">저장된 단어</span></h2>
+            <div className="flex items-center gap-3">
+              {error ? <span className="text-xs font-medium text-[#fb7185]">{error}</span> : null}
+              <span className="text-xs text-[#9499C4]">{loading ? "読み込み中..." : `${items?.length ?? 0}件`}</span>
+            </div>
+          </div>
           {loading ? (
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
               {Array.from({ length: 6 }).map((_, i) => (
@@ -159,7 +157,7 @@ export default function BookmarksPage() {
               </div>
             </Card>
           ) : null}
-        </Section>
+        </div>
       </div>
     </div>
   );

--- a/frontend/src/app/me/page.tsx
+++ b/frontend/src/app/me/page.tsx
@@ -8,7 +8,6 @@ import { useAuth } from "@/components/auth/AuthProvider";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { Input } from "@/components/ui/Input";
-import { Section } from "@/components/ui/Section";
 
 function parseApiError(err: unknown): { message: string; fieldErrors?: Record<string, string> } {
   if (!(err instanceof ApiError)) return { message: "更新に失敗しました。" };
@@ -171,18 +170,11 @@ export default function MePage() {
         </div>
 
         {!editing ? (
-          <Section
-            title="アカウント情報"
-            subtitle="계정 정보"
-            headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
-            titleClassName="text-[#F0F0FF]"
-            right={
-              <Button variant="ghost" type="button" onClick={handleEdit}>
-                編集
-              </Button>
-            }
-          >
-            <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
+          <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
+            <div className="mb-4 flex items-center justify-between border-b border-[rgba(255,255,255,0.06)] pb-4">
+              <h2 className="text-sm font-semibold text-[#F0F0FF]">アカウント情報 <span className="ml-1.5 text-xs font-medium text-[#9499C4]">계정 정보</span></h2>
+              <Button variant="ghost" type="button" onClick={handleEdit}>編集</Button>
+            </div>
               <dl className="grid grid-cols-3 gap-3 text-sm">
                 <dt className="text-[#9499C4]">ID</dt>
                 <dd className="col-span-2 break-all font-mono text-[#BCC0E8] text-xs">{state.user.id}</dd>
@@ -209,16 +201,12 @@ export default function MePage() {
                   ログアウト
                 </Button>
               </div>
-            </Card>
-          </Section>
+          </Card>
         ) : (
-          <Section
-            title="プロフィール編集"
-            subtitle="프로필 수정"
-            headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
-            titleClassName="text-[#F0F0FF]"
-          >
-            <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
+          <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
+            <div className="mb-4 flex items-center border-b border-[rgba(255,255,255,0.06)] pb-4">
+              <h2 className="text-sm font-semibold text-[#F0F0FF]">プロフィール編集 <span className="ml-1.5 text-xs font-medium text-[#9499C4]">프로필 수정</span></h2>
+            </div>
               <form onSubmit={handleSubmit} className="flex flex-col gap-4">
                 <Input
                   label="名前"
@@ -297,8 +285,7 @@ export default function MePage() {
                   </Button>
                 </div>
               </form>
-            </Card>
-          </Section>
+          </Card>
         )}
       </div>
     </div>

--- a/frontend/src/app/quiz/page.tsx
+++ b/frontend/src/app/quiz/page.tsx
@@ -9,7 +9,6 @@ import { VocabularyAudioPlayButton } from "@/components/vocabulary/VocabularyAud
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { Chip } from "@/components/ui/Chip";
-import { Section } from "@/components/ui/Section";
 import { addBookmark, listBookmarks, removeBookmark } from "@/lib/api/bookmarks";
 import { ApiError } from "@/lib/api/http";
 import { listVocabularies, type UserVocabulary } from "@/lib/api/vocabularies";
@@ -261,13 +260,10 @@ export default function QuizPage() {
           style={{ width: 500, height: 300, top: -50, left: "50%", transform: "translateX(-50%)" }}
         />
         <div className="relative mx-auto w-full max-w-lg space-y-6">
-          <Section
-            title="設定"
-            subtitle="설정"
-            headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
-            titleClassName="text-[#F0F0FF]"
-          >
-            <Card className="space-y-5 border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
+          <Card className="space-y-5 border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
+            <div className="flex items-center border-b border-[rgba(255,255,255,0.06)] pb-4">
+              <h2 className="text-sm font-semibold text-[#F0F0FF]">設定 <span className="ml-1.5 text-xs font-medium text-[#9499C4]">설정</span></h2>
+            </div>
               {/* 出題モード */}
               <div>
                 <div className="text-sm font-semibold text-[#BCC0E8]">
@@ -391,8 +387,7 @@ export default function QuizPage() {
               >
                 {loading ? "読み込み中..." : "スタート 시작"}
               </Button>
-            </Card>
-          </Section>
+          </Card>
         </div>
       </div>
     );
@@ -674,12 +669,8 @@ export default function QuizPage() {
 
         {/* 間違えた単語一覧 */}
         {wrongCards.length > 0 ? (
-          <Section
-            title="わからなかった語彙"
-            subtitle="모르겠던 단어"
-            headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
-            titleClassName="text-[#F0F0FF]"
-          >
+          <div className="space-y-3">
+            <h2 className="px-1 text-sm font-semibold text-[#F0F0FF]">わからなかった語彙 <span className="ml-1.5 text-xs font-medium text-[#9499C4]">모르겠던 단어</span></h2>
             <div className="space-y-2">
               {wrongCards.map(({ card }) => (
                 <div
@@ -732,7 +723,7 @@ export default function QuizPage() {
                 するとブックマークに即時保存できます
               </p>
             ) : null}
-          </Section>
+          </div>
         ) : (
           <div className="rounded-xl border border-[rgba(16,185,129,0.25)] bg-[rgba(16,185,129,0.1)] p-4 text-center text-sm font-semibold text-[#34d399] backdrop-blur-xl">
             🎉 すべて「わかった」です！완벽해요!

--- a/frontend/src/app/topik-practice/page.tsx
+++ b/frontend/src/app/topik-practice/page.tsx
@@ -6,7 +6,6 @@ import { useCallback, useState } from "react";
 import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { Chip } from "@/components/ui/Chip";
-import { Section } from "@/components/ui/Section";
 import { ApiError } from "@/lib/api/http";
 import { listQuestions, type TopikQuestion } from "@/lib/api/questions";
 
@@ -179,13 +178,10 @@ export default function TopikPracticePage() {
           style={{ width: 500, height: 300, top: -60, left: "50%", transform: "translateX(-50%)" }}
         />
         <div className="relative mx-auto w-full max-w-lg space-y-6">
-          <Section
-            title="設定"
-            subtitle="설정"
-            headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
-            titleClassName="text-[#F0F0FF]"
-          >
-            <Card className="space-y-5 border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
+          <Card className="space-y-5 border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
+            <div className="flex items-center border-b border-[rgba(255,255,255,0.06)] pb-4">
+              <h2 className="text-sm font-semibold text-[#F0F0FF]">設定 <span className="ml-1.5 text-xs font-medium text-[#9499C4]">설정</span></h2>
+            </div>
               {/* 問題タイプ */}
               <div>
                 <div className="text-sm font-semibold text-[#BCC0E8]">
@@ -250,8 +246,7 @@ export default function TopikPracticePage() {
               <Button className="w-full" type="button" disabled={loading} onClick={startQuiz}>
                 {loading ? "読み込み中..." : "スタート 시작"}
               </Button>
-            </Card>
-          </Section>
+          </Card>
 
           <div className="text-center">
             <Link href="/quiz" className="text-sm text-[#5C6199] underline underline-offset-2 hover:text-[#9499C4]">
@@ -477,12 +472,8 @@ export default function TopikPracticePage() {
         </div>
 
         {/* 問題別結果 */}
-        <Section
-          title="問題別結果"
-          subtitle="문제별 결과"
-          headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
-          titleClassName="text-[#F0F0FF]"
-        >
+        <div className="space-y-3">
+          <h2 className="px-1 text-sm font-semibold text-[#F0F0FF]">問題別結果 <span className="ml-1.5 text-xs font-medium text-[#9499C4]">문제별 결과</span></h2>
           <div className="space-y-3">
             {results.map((r, i) => {
               const correctOpt = r.question.options.find(
@@ -539,7 +530,7 @@ export default function TopikPracticePage() {
               );
             })}
           </div>
-        </Section>
+        </div>
 
         <div className="flex flex-col gap-2 sm:flex-row">
           <button

--- a/frontend/src/app/vocabularies/[id]/page.tsx
+++ b/frontend/src/app/vocabularies/[id]/page.tsx
@@ -9,7 +9,6 @@ import { HighlightedExampleText } from "@/components/vocabulary/HighlightedExamp
 import { VocabularyAudioPlayButton } from "@/components/vocabulary/VocabularyAudioPlayButton";
 import { Card } from "@/components/ui/Card";
 import { Chip } from "@/components/ui/Chip";
-import { Section } from "@/components/ui/Section";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { addBookmark, listBookmarks, removeBookmark } from "@/lib/api/bookmarks";
 import { ApiError } from "@/lib/api/http";
@@ -324,14 +323,10 @@ export default function VocabularyDetailPage() {
           </div>
         </Card>
 
-        <Section
-          title="例文"
-          subtitle="예문"
-          headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
-          titleClassName="text-[#F0F0FF]"
-          descriptionClassName="text-[#9499C4]"
-        >
-          <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
+        <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
+          <div className="mb-4 flex items-center border-b border-[rgba(255,255,255,0.06)] pb-4">
+            <h2 className="text-sm font-semibold text-[#F0F0FF]">例文 <span className="ml-1.5 text-xs font-medium text-[#9499C4]">예문</span></h2>
+          </div>
             <div className="grid gap-4 text-base leading-relaxed">
               {item?.example_sentence ? (
                 <div className="flex flex-wrap items-start justify-between gap-3">
@@ -372,8 +367,7 @@ export default function VocabularyDetailPage() {
                 </div>
               ) : null}
             </div>
-          </Card>
-        </Section>
+        </Card>
       </div>
     </div>
   );

--- a/frontend/src/app/vocabularies/page.tsx
+++ b/frontend/src/app/vocabularies/page.tsx
@@ -8,7 +8,6 @@ import { Button } from "@/components/ui/Button";
 import { Card } from "@/components/ui/Card";
 import { Chip } from "@/components/ui/Chip";
 import { Input } from "@/components/ui/Input";
-import { Section } from "@/components/ui/Section";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { VocabularyListVirtualGrid } from "@/components/vocabulary/VocabularyListVirtualGrid";
 import { ApiError } from "@/lib/api/http";
@@ -184,14 +183,9 @@ function VocabulariesPageInner() {
         style={{ width: 600, height: 400, top: -100, left: "50%", transform: "translateX(-50%)" }}
       />
       <div className="relative mx-auto w-full max-w-5xl space-y-6">
-        <Section
-          title="絞り込み"
-          subtitle="필터"
-          description="タップで絞り込み。もう一度タップで解除できます。"
-          headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
-          titleClassName="text-[#F0F0FF]"
-          descriptionClassName="text-[#9499C4]"
-          right={
+        <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
+          <div className="mb-4 flex items-center justify-between border-b border-[rgba(255,255,255,0.06)] pb-4">
+            <h2 className="text-sm font-semibold text-[#F0F0FF]">絞り込み <span className="ml-1.5 text-xs font-medium text-[#9499C4]">필터</span></h2>
             <Button
               variant="ghost"
               type="button"
@@ -202,9 +196,7 @@ function VocabulariesPageInner() {
             >
               リセット
             </Button>
-          }
-        >
-          <Card className="border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] text-[#F0F0FF] backdrop-blur-xl">
+          </div>
             <div className="space-y-4">
               <div>
                 <Input
@@ -280,18 +272,16 @@ function VocabulariesPageInner() {
                 </div>
               </div>
             </div>
-          </Card>
-        </Section>
+        </Card>
 
-        <Section
-          title="語彙一覧"
-          subtitle="단어 목록"
-          description={loading ? "読み込み中..." : `件数: ${items?.length ?? 0}`}
-          right={error ? <div className="text-sm font-medium text-[#fb7185]">{error}</div> : null}
-          headerClassName="rounded-2xl border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.05)] px-4 py-3 backdrop-blur-xl"
-          titleClassName="text-[#F0F0FF]"
-          descriptionClassName="text-[#9499C4]"
-        >
+        <div className="space-y-3">
+          <div className="flex items-center justify-between px-1">
+            <h2 className="text-sm font-semibold text-[#F0F0FF]">語彙一覧 <span className="ml-1.5 text-xs font-medium text-[#9499C4]">단어 목록</span></h2>
+            <div className="flex items-center gap-3">
+              {error ? <span className="text-xs font-medium text-[#fb7185]">{error}</span> : null}
+              <span className="text-xs text-[#9499C4]">{loading ? "読み込み中..." : `${items?.length ?? 0}件`}</span>
+            </div>
+          </div>
           {loading ? (
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
               {Array.from({ length: 9 }).map((_, i) => (
@@ -315,7 +305,7 @@ function VocabulariesPageInner() {
               <div className="mt-1 text-sm text-[#9499C4]">絞り込みをリセットしてみてください。</div>
             </Card>
           ) : null}
-        </Section>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- `Section` コンポーネントのヘッダーをカード外に独立表示していた設計を廃止
- 単一カードセクション（設定・絞り込み・例文・アカウント情報・プロフィール編集）: タイトル＋区切り線をカード内に統合（パターンA）
- グリッド/リストセクション（語彙一覧・保存済み語彙・わからなかった語彙・問題別結果）: カードの外にインライン `h2` ラベル＋件数バッジのシンプルな行に変更

## Files Changed

- `quiz/page.tsx` — 設定 / わからなかった語彙
- `topik-practice/page.tsx` — 設定 / 問題別結果
- `vocabularies/page.tsx` — 絞り込み / 語彙一覧
- `vocabularies/[id]/page.tsx` — 例文
- `bookmarks/page.tsx` — 保存済み語彙
- `me/page.tsx` — アカウント情報 / プロフィール編集

## Test plan

- [ ] `/quiz` — 設定カードにタイトルが表示される
- [ ] `/quiz` 結果画面 — わからなかった語彙にインラインh2が表示される
- [ ] `/topik-practice` — 同上
- [ ] `/vocabularies` — 絞り込みカード内にタイトル、語彙一覧はインラインh2
- [ ] `/vocabularies/[id]` — 例文カード内にタイトル
- [ ] `/bookmarks` — 保存済み語彙にインラインh2
- [ ] `/me` — アカウント情報・プロフィール編集カード内にタイトル

🤖 Generated with [Claude Code](https://claude.com/claude-code)